### PR TITLE
feat: implement post-authentication redirect via redirect_after_login parameter

### DIFF
--- a/src/app/pages/Router.tsx
+++ b/src/app/pages/Router.tsx
@@ -87,9 +87,14 @@ export const createRouter = (clientConfig: ClientConfig, screenSize: ScreenSize)
         }}
       />
       <Route
-        loader={() => {
+        loader={({ request }) => {
           if (getFallbackSession()) {
             return redirect(getHomePath());
+          }
+          const url = new URL(request.url);
+          const redirectAfterLogin = url.searchParams.get('redirect_after_login');
+          if (redirectAfterLogin) {
+            setAfterLoginRedirectPath(redirectAfterLogin);
           }
 
           return null;

--- a/src/app/pages/auth/login/Login.tsx
+++ b/src/app/pages/auth/login/Login.tsx
@@ -13,6 +13,7 @@ import { getLoginPath, getRegisterPath, withSearchParam } from '../../pathUtils'
 import { usePathWithOrigin } from '../../../hooks/usePathWithOrigin';
 import { LoginPathSearchParams } from '../../paths';
 import { useClientConfig } from '../../../hooks/useClientConfig';
+import { setAfterLoginRedirectPath } from '../../afterLoginRedirectPath';
 
 const getLoginTokenSearchParam = () => {
   // when using hasRouter query params in existing route
@@ -30,6 +31,7 @@ const useLoginSearchParams = (searchParams: URLSearchParams): LoginPathSearchPar
       username: searchParams.get('username') ?? undefined,
       email: searchParams.get('email') ?? undefined,
       loginToken: searchParams.get('loginToken') ?? undefined,
+      redirect_after_login: searchParams.get('redirect_after_login') ?? undefined,
     }),
     [searchParams]
   );
@@ -53,6 +55,18 @@ export function Login() {
   }
 
   const parsedFlows = useParsedLoginFlows(loginFlows.flows);
+
+  React.useEffect(() => {
+    if (loginSearchParams.redirect_after_login) {
+      setAfterLoginRedirectPath(loginSearchParams.redirect_after_login);
+    }
+  }, [loginSearchParams.redirect_after_login]);
+
+  const registerPath = loginSearchParams.redirect_after_login
+    ? withSearchParam(getRegisterPath(server), {
+        redirect_after_login: loginSearchParams.redirect_after_login,
+      })
+    : getRegisterPath(server);
 
   return (
     <Box direction="Column" gap="500">
@@ -92,7 +106,7 @@ export function Login() {
         </>
       )}
       <Text align="Center">
-        Do not have an account? <Link to={getRegisterPath(server)}>Register</Link>
+        Do not have an account? <Link to={registerPath}>Register</Link>
       </Text>
     </Box>
   );

--- a/src/app/pages/auth/register/Register.tsx
+++ b/src/app/pages/auth/register/Register.tsx
@@ -12,6 +12,8 @@ import { SupportedUIAFlowsLoader } from '../../../components/SupportedUIAFlowsLo
 import { getLoginPath } from '../../pathUtils';
 import { usePathWithOrigin } from '../../../hooks/usePathWithOrigin';
 import { RegisterPathSearchParams } from '../../paths';
+import { setAfterLoginRedirectPath } from '../../afterLoginRedirectPath';
+import { withSearchParam } from '../../pathUtils';
 
 const useRegisterSearchParams = (searchParams: URLSearchParams): RegisterPathSearchParams =>
   useMemo(
@@ -19,6 +21,7 @@ const useRegisterSearchParams = (searchParams: URLSearchParams): RegisterPathSea
       username: searchParams.get('username') ?? undefined,
       email: searchParams.get('email') ?? undefined,
       token: searchParams.get('token') ?? undefined,
+      redirect_after_login: searchParams.get('redirect_after_login') ?? undefined,
     }),
     [searchParams]
   );
@@ -32,6 +35,18 @@ export function Register() {
 
   // redirect to /login because only that path handle m.login.token
   const ssoRedirectUrl = usePathWithOrigin(getLoginPath(server));
+
+  React.useEffect(() => {
+    if (registerSearchParams.redirect_after_login) {
+      setAfterLoginRedirectPath(registerSearchParams.redirect_after_login);
+    }
+  }, [registerSearchParams.redirect_after_login]);
+
+  const loginPath = registerSearchParams.redirect_after_login
+    ? withSearchParam(getLoginPath(server), {
+        redirect_after_login: registerSearchParams.redirect_after_login,
+      })
+    : getLoginPath(server);
 
   return (
     <Box direction="Column" gap="500">
@@ -91,7 +106,7 @@ export function Register() {
         </>
       )}
       <Text align="Center">
-        Already have an account? <Link to={getLoginPath(server)}>Login</Link>
+        Already have an account? <Link to={loginPath}>Login</Link>
       </Text>
     </Box>
   );

--- a/src/app/pages/paths.ts
+++ b/src/app/pages/paths.ts
@@ -4,6 +4,7 @@ export type LoginPathSearchParams = {
   username?: string;
   email?: string;
   loginToken?: string;
+  redirect_after_login?: string;
 };
 export const LOGIN_PATH = '/login/:server?/';
 
@@ -11,6 +12,7 @@ export type RegisterPathSearchParams = {
   username?: string;
   email?: string;
   token?: string;
+  redirect_after_login?: string;
 };
 export const REGISTER_PATH = '/register/:server?/';
 


### PR DESCRIPTION
When someone shares a link to join a room or community they usually get sent to the page after they log in. Then they have to find their way to where they wanted to go. This change makes it easier for people to get to where they want to go.

The solution is to add something called redirect_after_login to the login and register pages. When someone uses this the app will automatically send them to the place after they log in or register.

Here are the main things that changed:

* I added redirect_after_login to the search parameters for login and register pages.

* I made it so the app checks for this parameter soon as someone starts logging in.

* I made sure the redirect_after_login parameter is not lost when people switch between the login and register pages.

* I used something called afterLoginRedirectPath to store where the person wants to go. It is not forgotten during the login process.

To test this you can do the following:

1. Make a link to the login. Register page, with the redirect parameter:

http://localhost:3000/#/login?redirect_after_login=%23%2Fhome%2Froom%2F!roomid%3Aexample.com

2. Log in. Register.

3. Check that the app sends you to the room you wanted to go to after you log in.