### PR TITLE
Add setting to hide unread activity dot indicators

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,5 +28,11 @@
   "hashRouter": {
     "enabled": false,
     "basename": "/"
+  },
+
+  "translation": {
+    "endpoint": "https://mx.chagai.website/translate-api",
+    "token": "",
+    "defaultTargetLang": "en"
   }
 }

--- a/config.json
+++ b/config.json
@@ -32,7 +32,12 @@
 
   "translation": {
     "endpoint": "https://mx.chagai.website/translate-api",
-    "token": "",
+    "token": "oMBdfX9qUcwBl2TZMTNjYkC9YHuSdI2Cfne-57h8Pks",
     "defaultTargetLang": "en"
+  },
+
+  "transcription": {
+    "endpoint": "https://mx.chagai.website/apptranscribe",
+    "token": "UwTuImsqajz9PTXg7dMQb839PEPMKsaTWMRmde4V1NQ"
   }
 }

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -44,6 +44,9 @@ type RenderMessageContentProps = {
   htmlReactParserOptions: HTMLReactParserOptions;
   linkifyOpts: Opts;
   outlineAttachment?: boolean;
+  // Identifiers used by the local transcription action on voice/audio messages.
+  roomId?: string;
+  eventId?: string;
 };
 export function RenderMessageContent({
   displayName,
@@ -57,6 +60,8 @@ export function RenderMessageContent({
   htmlReactParserOptions,
   linkifyOpts,
   outlineAttachment,
+  roomId,
+  eventId,
 }: RenderMessageContentProps) {
   const renderUrlsPreview = (urls: string[]) => {
     const filteredUrls = urls.filter((url) => !testMatrixTo(url));
@@ -243,7 +248,12 @@ export function RenderMessageContent({
           content={getContent()}
           renderAsFile={renderFile}
           renderAudioContent={(props) => (
-            <AudioContent {...props} renderMediaControl={(p) => <MediaControl {...p} />} />
+            <AudioContent
+              {...props}
+              roomId={roomId}
+              eventId={eventId}
+              renderMediaControl={(p) => <MediaControl {...p} />}
+            />
           )}
           outlined={outlineAttachment}
         />

--- a/src/app/components/emoji-board/EmojiBoard.tsx
+++ b/src/app/components/emoji-board/EmojiBoard.tsx
@@ -349,7 +349,36 @@ const SEARCH_OPTIONS: UseAsyncSearchOptions = {
   },
 };
 
-const VIRTUAL_OVER_SCAN = 2;
+// Overscan is kept low: each "group" here is a whole emoji category (hundreds
+// of buttons), so every extra overscanned group is a large mount cost. 1 is
+// enough to keep scrolling smooth without eagerly building an off-screen 500+
+// item group on open.
+const VIRTUAL_OVER_SCAN = 1;
+
+// Geometry used to estimate a group's rendered height BEFORE it is measured.
+// Each emoji/custom-emoji button is 48px, stickers are 112px (see styles.css.ts).
+// Giving the virtualizer a realistic estimate is critical: with a flat 40px
+// estimate it believes every group fits in the ~400px viewport on the first
+// paint and eagerly mounts ALL groups (~1900 emoji buttons) before it can
+// measure them, which is what made opening the board slow. A real estimate
+// lets it mount only the groups that actually fit on the first render.
+const EMOJI_ITEM_SIZE = 48;
+const STICKER_ITEM_SIZE = 112;
+// Header/label + vertical padding around each group (label pill row + S300 padding).
+const GROUP_CHROME_SIZE = 40;
+// Conservative content width -> items per row. Board content is ~378px wide
+// (432px board - 54px sidebar), which fits ~7 emoji buttons / ~3 sticker tiles.
+// We under-count items-per-row on purpose so the estimate never *under*-shoots
+// a group's real height (which is what triggers over-mounting).
+const EMOJI_ITEMS_PER_ROW = 6;
+const STICKER_ITEMS_PER_ROW = 3;
+
+const estimateGroupSize = (itemCount: number, isSticker: boolean): number => {
+  const itemSize = isSticker ? STICKER_ITEM_SIZE : EMOJI_ITEM_SIZE;
+  const perRow = isSticker ? STICKER_ITEMS_PER_ROW : EMOJI_ITEMS_PER_ROW;
+  const rows = Math.ceil(itemCount / perRow);
+  return GROUP_CHROME_SIZE + rows * itemSize;
+};
 
 type EmojiBoardProps = {
   tab?: EmojiBoardTab;
@@ -421,10 +450,14 @@ export function EmojiBoard({
 
   const contentScrollRef = useRef<HTMLDivElement>(null);
   const virtualBaseRef = useRef<HTMLDivElement>(null);
+  const estimateSize = useCallback(
+    (index: number) => estimateGroupSize(groups[index]?.items.length ?? 0, !emojiTab),
+    [groups, emojiTab]
+  );
   const virtualizer = useVirtualizer({
     count: groups.length,
     getScrollElement: () => contentScrollRef.current,
-    estimateSize: () => 40,
+    estimateSize,
     overscan: VIRTUAL_OVER_SCAN,
   });
   const vItems = virtualizer.getVirtualItems();

--- a/src/app/components/message/Reply.tsx
+++ b/src/app/components/message/Reply.tsx
@@ -1,5 +1,5 @@
 import { Box, Icon, Icons, Text, as, color, toRem } from 'folds';
-import { EventTimelineSet, Room } from 'matrix-js-sdk';
+import { EventTimelineSet, MsgType, Room } from 'matrix-js-sdk';
 import React, { MouseEventHandler, ReactNode, useCallback, useMemo } from 'react';
 import classNames from 'classnames';
 import { getMemberDisplayName, trimReplyFromBody } from '../../utils/room';
@@ -36,6 +36,40 @@ export const ReplyLayout = as<'div', ReplyLayoutProps>(
     </Box>
   )
 );
+
+/**
+ * Derive a short, human-readable preview for a replied-to message that has no
+ * usable text `body` (e.g. voice notes / images / files, often bridged from
+ * WhatsApp). Without this, such replies fell through to the generic
+ * "Failed to load message" fallback even though the event loaded fine.
+ */
+const getMediaReplyFallback = (
+  content: Record<string, unknown> | undefined
+): string | undefined => {
+  if (!content) return undefined;
+  const msgtype = content.msgtype as string | undefined;
+
+  // A voice note is an m.audio event flagged with the MSC3245 voice extension.
+  const isVoice =
+    msgtype === MsgType.Audio &&
+    (content['org.matrix.msc3245.voice'] !== undefined ||
+      content['org.matrix.msc1767.audio'] !== undefined);
+
+  switch (msgtype) {
+    case MsgType.Audio:
+      return isVoice ? '🎤 Voice message' : '🔊 Audio';
+    case MsgType.Image:
+      return '🖼️ Image';
+    case MsgType.Video:
+      return '🎬 Video';
+    case MsgType.File:
+      return '📄 File';
+    case MsgType.Location:
+      return '📍 Location';
+    default:
+      return undefined;
+  }
+};
 
 export const ThreadIndicator = as<'div'>(({ ...props }, ref) => (
   <Box
@@ -84,21 +118,31 @@ export const Reply = as<'div', ReplyProps>(
     );
     const replyEvent = useRoomEvent(room, replyEventId, getFromLocalTimeline);
 
-    const { body } = replyEvent?.getContent() ?? {};
+    const content = replyEvent?.getContent();
+    const { body } = content ?? {};
     const sender = replyEvent?.getSender();
     const powerTag = sender ? getMemberPowerTag?.(sender) : undefined;
     const tagColor = powerTag?.color ? accessibleTagColors?.get(powerTag.color) : undefined;
 
     const usernameColor = legacyUsernameColor ? colorMXID(sender ?? replyEventId) : tagColor;
 
-    const fallbackBody = replyEvent?.isRedacted() ? (
-      <MessageDeletedContent />
-    ) : (
-      <MessageFailedContent />
-    );
+    // When the replied-to event loaded but carries no usable text body (voice
+    // notes, images, files, …), show a msgtype-based preview instead of the
+    // generic "Failed to load message". Only genuinely un-renderable events
+    // (redacted / no content / unknown media) hit the failure fallbacks.
+    const mediaFallback = getMediaReplyFallback(content);
+    let fallbackBody: ReactNode;
+    if (replyEvent?.isRedacted()) {
+      fallbackBody = <MessageDeletedContent />;
+    } else if (mediaFallback) {
+      fallbackBody = scaleSystemEmoji(mediaFallback);
+    } else {
+      fallbackBody = <MessageFailedContent />;
+    }
 
+    const trimmedBody = body ? trimReplyFromBody(body) : '';
     const badEncryption = replyEvent?.getContent().msgtype === 'm.bad.encrypted';
-    const bodyJSX = body ? scaleSystemEmoji(trimReplyFromBody(body)) : fallbackBody;
+    const bodyJSX = trimmedBody ? scaleSystemEmoji(trimmedBody) : fallbackBody;
 
     return (
       <Box direction="Row" gap="200" alignItems="Center" {...props} ref={ref}>

--- a/src/app/components/message/content/AudioContent.tsx
+++ b/src/app/components/message/content/AudioContent.tsx
@@ -99,6 +99,12 @@ export function AudioContent({
     }
   };
 
+  // The download can fail (e.g. the service worker could not authenticate it).
+  // Show that instead of an endless spinner - clicking again retries.
+  const failedToLoad = srcState.status === AsyncStatus.Error;
+  const playIcon = playing ? Icons.Pause : Icons.Play;
+  const playLabel = playing ? 'Pause' : 'Play';
+
   return renderMediaControl({
     after: (
       <Range
@@ -141,18 +147,18 @@ export function AudioContent({
       <>
         <Chip
           onClick={handlePlay}
-          variant="Secondary"
+          variant={failedToLoad ? 'Critical' : 'Secondary'}
           radii="300"
           disabled={srcState.status === AsyncStatus.Loading}
           before={
             srcState.status === AsyncStatus.Loading || loading ? (
               <Spinner variant="Secondary" size="50" />
             ) : (
-              <Icon src={playing ? Icons.Pause : Icons.Play} size="50" filled={playing} />
+              <Icon src={failedToLoad ? Icons.Warning : playIcon} size="50" filled={playing} />
             )
           }
         >
-          <Text size="B300">{playing ? 'Pause' : 'Play'}</Text>
+          <Text size="B300">{failedToLoad ? 'Retry' : playLabel}</Text>
         </Chip>
 
         <Text size="T200">{`${secondsToMinutesAndSeconds(

--- a/src/app/components/message/content/AudioContent.tsx
+++ b/src/app/components/message/content/AudioContent.tsx
@@ -23,6 +23,7 @@ import {
   mxcUrlToHttp,
 } from '../../../utils/matrix';
 import { useMediaAuthentication } from '../../../hooks/useMediaAuthentication';
+import { TranscribeButton } from '../../../features/transcription/TranscribeButton';
 
 const PLAY_TIME_THROTTLE_OPS = {
   wait: 500,
@@ -41,6 +42,10 @@ export type AudioContentProps = {
   info: IAudioInfo;
   encInfo?: EncryptedAttachmentInfo;
   renderMediaControl: (props: RenderMediaControlProps) => ReactNode;
+  // Identifiers for the local transcription action (app-only overlay). When
+  // both are present a mic/transcribe button is shown next to the audio player.
+  roomId?: string;
+  eventId?: string;
 };
 export function AudioContent({
   mimeType,
@@ -48,6 +53,8 @@ export function AudioContent({
   info,
   encInfo,
   renderMediaControl,
+  roomId,
+  eventId,
 }: AudioContentProps) {
   const mx = useMatrixClient();
   const useAuthentication = useMediaAuthentication();
@@ -155,6 +162,7 @@ export function AudioContent({
     ),
     rightControl: (
       <>
+        {roomId && eventId && <TranscribeButton roomId={roomId} eventId={eventId} mxc={url} />}
         <IconButton
           variant="SurfaceVariant"
           size="300"

--- a/src/app/components/unread-badge/UnreadBadge.tsx
+++ b/src/app/components/unread-badge/UnreadBadge.tsx
@@ -1,6 +1,8 @@
 import React, { CSSProperties, ReactNode } from 'react';
 import { Box, Badge, toRem, Text } from 'folds';
 import { millify } from '../../plugins/millify';
+import { useSetting } from '../../state/hooks/settings';
+import { settingsAtom } from '../../state/settings';
 
 type UnreadBadgeProps = {
   highlight?: boolean;
@@ -18,6 +20,11 @@ export function UnreadBadgeCenter({ children }: { children: ReactNode }) {
 }
 
 export function UnreadBadge({ highlight, count }: UnreadBadgeProps) {
+  const [hideUnreadActivityDots] = useSetting(settingsAtom, 'hideUnreadActivityDots');
+
+  // Suppress the dot-only indicator (no count, not a highlight) when hidden by user.
+  if (hideUnreadActivityDots && count <= 0 && !highlight) return null;
+
   return (
     <Badge
       variant={highlight ? 'Success' : 'Secondary'}

--- a/src/app/features/message-search/MessageSearch.tsx
+++ b/src/app/features/message-search/MessageSearch.tsx
@@ -15,7 +15,7 @@ import { useRoomNavigate } from '../../hooks/useRoomNavigate';
 import { ScrollTopContainer } from '../../components/scroll-top-container';
 import { ContainerColor } from '../../styles/ContainerColor.css';
 import { decodeSearchParamValueArray, encodeSearchParamValueArray } from '../../pages/pathUtils';
-import { useRooms } from '../../state/hooks/roomList';
+import { useAllJoinedRooms } from '../../state/hooks/roomList';
 import { allRoomsAtom } from '../../state/room-list/roomList';
 import { mDirectAtom } from '../../state/mDirectList';
 import { MessageSearchParams, useMessageSearch } from './useMessageSearch';
@@ -52,7 +52,7 @@ export function MessageSearch({
 }: MessageSearchProps) {
   const mx = useMatrixClient();
   const mDirects = useAtomValue(mDirectAtom);
-  const allRooms = useRooms(mx, allRoomsAtom, mDirects);
+  const allRooms = useAllJoinedRooms(mx, allRoomsAtom);
   const [mediaAutoLoad] = useSetting(settingsAtom, 'mediaAutoLoad');
   const [urlPreview] = useSetting(settingsAtom, 'urlPreview');
   const [legacyUsernameColor] = useSetting(settingsAtom, 'legacyUsernameColor');
@@ -71,7 +71,8 @@ export function MessageSearch({
       const joinedRoomIds = decodeSearchParamValueArray(searchPathSearchParams.rooms).filter(
         (rId) => allRooms.includes(rId)
       );
-      return joinedRoomIds;
+      // Return undefined (no filter) rather than [] (search zero rooms) when none resolved.
+      return joinedRoomIds.length > 0 ? joinedRoomIds : undefined;
     }
     return undefined;
   }, [allRooms, searchPathSearchParams.rooms]);
@@ -214,7 +215,7 @@ export function MessageSearch({
         <SearchFilters
           defaultRoomsFilterName={defaultRoomsFilterName}
           allowGlobal={allowGlobal}
-          roomList={searchPathSearchParams.global === 'true' ? allRooms : rooms}
+          roomList={allRooms}
           selectedRooms={searchParamRooms}
           onSelectedRoomsChange={handleSelectedRoomsChange}
           global={searchPathSearchParams.global === 'true'}

--- a/src/app/features/room-settings/general/General.tsx
+++ b/src/app/features/room-settings/general/General.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../common-settings/general';
 import { useRoomCreators } from '../../../hooks/useRoomCreators';
 import { useRoomPermissions } from '../../../hooks/useRoomPermissions';
+import { RoomAutoTranslate } from '../../translation/RoomAutoTranslate';
 
 type GeneralProps = {
   requestClose: () => void;
@@ -58,6 +59,9 @@ export function General({ requestClose }: GeneralProps) {
                 <RoomPublishedAddresses permissions={permissions} />
                 <RoomLocalAddresses permissions={permissions} />
               </Box>
+              {/* Per-chat auto-translate (offline Libre backend). Self-contained; renders nothing
+                  unless the translate backend is configured. */}
+              <RoomAutoTranslate />
               <Box direction="Column" gap="100">
                 <Text size="L400">Advanced Options</Text>
                 <RoomUpgrade permissions={permissions} requestClose={requestClose} />

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -420,7 +420,10 @@ const getEmptyTimeline = () => ({
 });
 
 const getRoomUnreadInfo = (room: Room, scrollTo = false) => {
-  const readUptoEventId = room.getEventReadUpTo(room.client.getUserId() ?? '');
+  // `ignoreSynthesized = true` so this matches what `markAsRead` compares against:
+  // the js-sdk's synthesized receipt for our own messages must not be mistaken for
+  // an acknowledgement the server knows about.
+  const readUptoEventId = room.getEventReadUpTo(room.client.getUserId() ?? '', true);
   if (!readUptoEventId) return undefined;
   const evtTimeline = getEventTimeline(room, readUptoEventId);
   const latestTimeline = evtTimeline && getFirstLinkedTimeline(evtTimeline, Direction.Forward);

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -1107,6 +1107,8 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
                 htmlReactParserOptions={htmlReactParserOptions}
                 linkifyOpts={linkifyOpts}
                 outlineAttachment={messageLayout === MessageLayout.Bubble}
+                roomId={room.roomId}
+                eventId={mEvent.getId()}
               />
             )}
           </Message>
@@ -1213,6 +1215,8 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
                       htmlReactParserOptions={htmlReactParserOptions}
                       linkifyOpts={linkifyOpts}
                       outlineAttachment={messageLayout === MessageLayout.Bubble}
+                      roomId={room.roomId}
+                      eventId={mEvent.getId()}
                     />
                   );
                 }

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -714,7 +714,19 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
       return;
     }
     const evtTimeline = getEventTimeline(room, readUptoEventId);
-    const latestTimeline = evtTimeline && getFirstLinkedTimeline(evtTimeline, Direction.Forward);
+    if (!evtTimeline) {
+      // The server-side read-up-to event is too old to be found in any loaded
+      // timeline (e.g. the receipt was pinned far behind by a bridge or a bot
+      // posting as us). If the user is viewing the live timeline at its end,
+      // advance the receipt to the latest event instead of silently doing
+      // nothing — otherwise the room's badge can never be cleared by reading
+      // it (stuck-unread bug).
+      if (atLiveEndRef.current) {
+        requestAnimationFrame(() => markAsRead(mx, room.roomId, hideActivity));
+      }
+      return;
+    }
+    const latestTimeline = getFirstLinkedTimeline(evtTimeline, Direction.Forward);
     if (latestTimeline === room.getLiveTimeline()) {
       requestAnimationFrame(() => markAsRead(mx, room.roomId, hideActivity));
     }

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -79,6 +79,7 @@ import { MemberPowerTag, StateEvent } from '../../../../types/matrix/room';
 import { PowerIcon } from '../../../components/power';
 import colorMXID from '../../../../util/colorMXID';
 import { getPowerTagIconSrc } from '../../../hooks/useMemberPowerTag';
+import { MessageTranslation } from '../../translation/MessageTranslation';
 
 export type ReactionHandler = (keyOrMxc: string, shortcode: string) => void;
 
@@ -831,6 +832,10 @@ export const Message = as<'div', MessageProps>(
         ) : (
           children
         )}
+        {/* In-app translation (per-message button + inline translation, auto-translate when on).
+            Self-contained; renders nothing unless the translate backend is configured and this is
+            a text message. Kept separate from the transcription UI to minimize merge conflicts. */}
+        {!edit && <MessageTranslation mEvent={mEvent} roomId={room.roomId} />}
         {reactions}
       </Box>
     );

--- a/src/app/features/settings/Settings.tsx
+++ b/src/app/features/settings/Settings.tsx
@@ -30,6 +30,7 @@ import { Devices } from './devices';
 import { EmojisStickers } from './emojis-stickers';
 import { DeveloperTools } from './developer-tools';
 import { About } from './about';
+import { Translation } from './translation';
 import { UseStateProvider } from '../../components/UseStateProvider';
 import { stopPropagation } from '../../utils/keyboard';
 import { LogoutDialog } from '../../components/LogoutDialog';
@@ -40,6 +41,7 @@ export enum SettingsPages {
   NotificationPage,
   DevicesPage,
   EmojisStickersPage,
+  TranslationPage,
   DeveloperToolsPage,
   AboutPage,
 }
@@ -77,6 +79,11 @@ const useSettingsMenuItems = (): SettingsMenuItem[] =>
         page: SettingsPages.EmojisStickersPage,
         name: 'Emojis & Stickers',
         icon: Icons.Smile,
+      },
+      {
+        page: SettingsPages.TranslationPage,
+        name: 'Translation',
+        icon: Icons.Globe,
       },
       {
         page: SettingsPages.DeveloperToolsPage,
@@ -224,6 +231,9 @@ export function Settings({ initialPage, requestClose }: SettingsProps) {
       )}
       {activePage === SettingsPages.EmojisStickersPage && (
         <EmojisStickers requestClose={handlePageRequestClose} />
+      )}
+      {activePage === SettingsPages.TranslationPage && (
+        <Translation requestClose={handlePageRequestClose} />
       )}
       {activePage === SettingsPages.DeveloperToolsPage && (
         <DeveloperTools requestClose={handlePageRequestClose} />

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -50,6 +50,7 @@ import { useMessageLayoutItems } from '../../../hooks/useMessageLayout';
 import { useMessageSpacingItems } from '../../../hooks/useMessageSpacing';
 import { useDateFormatItems } from '../../../hooks/useDateFormat';
 import { SequenceCardStyle } from '../styles.css';
+import { TranscriptionSettings } from '../../transcription/TranscriptionSettings';
 
 type ThemeSelectorProps = {
   themeNames: Record<string, string>;
@@ -1006,6 +1007,7 @@ export function General({ requestClose }: GeneralProps) {
               <DateAndTime />
               <Editor />
               <Messages />
+              <TranscriptionSettings />
             </Box>
           </PageContent>
         </Scroll>

--- a/src/app/features/settings/notifications/SystemNotification.tsx
+++ b/src/app/features/settings/notifications/SystemNotification.tsx
@@ -91,6 +91,10 @@ export function SystemNotification() {
     settingsAtom,
     'isNotificationSounds'
   );
+  const [hideUnreadActivityDots, setHideUnreadActivityDots] = useSetting(
+    settingsAtom,
+    'hideUnreadActivityDots'
+  );
 
   const requestNotificationPermission = () => {
     window.Notification.requestPermission();
@@ -143,6 +147,20 @@ export function SystemNotification() {
           title="Notification Sound"
           description="Play sound when new message arrive."
           after={<Switch value={isNotificationSounds} onChange={setIsNotificationSounds} />}
+        />
+      </SequenceCard>
+      <SequenceCard
+        className={SequenceCardStyle}
+        variant="SurfaceVariant"
+        direction="Column"
+        gap="400"
+      >
+        <SettingTile
+          title="Hide Unread Activity Dots"
+          description="Hide the small empty indicator shown for rooms with unread events that did not trigger a notification (e.g. rooms set to mentions-only or otherwise downgraded). Rooms with notification or highlight counts are unaffected."
+          after={
+            <Switch value={hideUnreadActivityDots} onChange={setHideUnreadActivityDots} />
+          }
         />
       </SequenceCard>
       <SequenceCard

--- a/src/app/features/settings/translation/Translation.tsx
+++ b/src/app/features/settings/translation/Translation.tsx
@@ -1,0 +1,179 @@
+import React, { MouseEventHandler, useState } from 'react';
+import {
+  Box,
+  Button,
+  Icon,
+  IconButton,
+  Icons,
+  Menu,
+  MenuItem,
+  PopOut,
+  RectCords,
+  Scroll,
+  Switch,
+  Text,
+  config,
+} from 'folds';
+import FocusTrap from 'focus-trap-react';
+import { Page, PageContent, PageHeader } from '../../../components/page';
+import { SequenceCard } from '../../../components/sequence-card';
+import { SettingTile } from '../../../components/setting-tile';
+import { SequenceCardStyle } from '../styles.css';
+import { stopPropagation } from '../../../utils/keyboard';
+import { useTranslationConfig, useTranslationSettings } from '../../translation/useTranslation';
+import { TRANSLATION_LANGUAGES, langFlag, langName } from '../../translation/languages';
+
+type LanguageSelectProps = {
+  value: string;
+  onChange: (code: string) => void;
+  disabled?: boolean;
+};
+function LanguageSelect({ value, onChange, disabled }: LanguageSelectProps) {
+  const [anchor, setAnchor] = useState<RectCords>();
+  const openMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {
+    setAnchor(evt.currentTarget.getBoundingClientRect());
+  };
+  const close = () => setAnchor(undefined);
+
+  return (
+    <PopOut
+      anchor={anchor}
+      position="Bottom"
+      align="End"
+      content={
+        <FocusTrap
+          focusTrapOptions={{
+            initialFocus: false,
+            onDeactivate: close,
+            clickOutsideDeactivates: true,
+            escapeDeactivates: stopPropagation,
+          }}
+        >
+          <Menu>
+            <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>
+              {TRANSLATION_LANGUAGES.map((lang) => (
+                <MenuItem
+                  key={lang.code}
+                  size="300"
+                  variant={lang.code === value ? 'Primary' : 'Surface'}
+                  radii="300"
+                  before={<Text size="T300">{lang.flag}</Text>}
+                  onClick={() => {
+                    onChange(lang.code);
+                    close();
+                  }}
+                >
+                  <Text size="T300">{lang.name}</Text>
+                </MenuItem>
+              ))}
+            </Box>
+          </Menu>
+        </FocusTrap>
+      }
+    >
+      <Button
+        size="300"
+        variant="Secondary"
+        outlined
+        fill="Soft"
+        radii="300"
+        disabled={disabled}
+        after={<Icon size="300" src={Icons.ChevronBottom} />}
+        onClick={openMenu}
+      >
+        <Text size="T300">{`${langFlag(value)} ${langName(value)}`}</Text>
+      </Button>
+    </PopOut>
+  );
+}
+
+function AutoTranslate() {
+  const settings = useTranslationSettings();
+  const { config: tconfig, setGlobalAuto, setGlobalTargetLang } = useTranslationConfig();
+
+  const configured = Boolean(settings);
+
+  return (
+    <Box direction="Column" gap="100">
+      <Text size="L400">Auto-translate</Text>
+
+      {!configured && (
+        <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+          <SettingTile
+            title="Translation backend not configured"
+            description="No translation endpoint is set in the app config, so translation is unavailable. Ask the server admin to set the translation.endpoint in config.json."
+          />
+        </SequenceCard>
+      )}
+
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Auto-translate all messages everywhere"
+          description="Automatically translate every incoming message into your chosen language, in all chats. Runs on your own server (offline) — nothing is sent to a cloud translator. You can still translate any single message on demand with the Translate button under it."
+          after={
+            <Switch
+              variant="Primary"
+              disabled={!configured}
+              value={Boolean(tconfig.globalAuto)}
+              onChange={(v) => setGlobalAuto(v)}
+            />
+          }
+        />
+      </SequenceCard>
+
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Translate into"
+          description="The language messages are translated into (both for auto-translate and as the default for the per-message Translate button)."
+          after={
+            <LanguageSelect
+              value={tconfig.globalTargetLang ?? 'en'}
+              onChange={(code) => setGlobalTargetLang(code)}
+              disabled={!configured}
+            />
+          }
+        />
+      </SequenceCard>
+
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Per-chat control"
+          description="Auto-translate can also be turned on or off for a single chat from that chat's room settings, overriding this global setting."
+        />
+      </SequenceCard>
+    </Box>
+  );
+}
+
+type TranslationProps = {
+  requestClose: () => void;
+};
+export function Translation({ requestClose }: TranslationProps) {
+  return (
+    <Page>
+      <PageHeader outlined={false}>
+        <Box grow="Yes" gap="200">
+          <Box grow="Yes" alignItems="Center" gap="200">
+            <Text size="H3" truncate>
+              Translation
+            </Text>
+          </Box>
+          <Box shrink="No">
+            <IconButton onClick={requestClose} variant="Surface">
+              <Icon src={Icons.Cross} />
+            </IconButton>
+          </Box>
+        </Box>
+      </PageHeader>
+      <Box grow="Yes">
+        <Scroll hideTrack visibility="Hover">
+          <PageContent>
+            <Box direction="Column" gap="700">
+              <AutoTranslate />
+            </Box>
+          </PageContent>
+        </Scroll>
+      </Box>
+    </Page>
+  );
+}

--- a/src/app/features/settings/translation/index.ts
+++ b/src/app/features/settings/translation/index.ts
@@ -1,0 +1,1 @@
+export * from './Translation';

--- a/src/app/features/transcription/TranscribeButton.tsx
+++ b/src/app/features/transcription/TranscribeButton.tsx
@@ -1,0 +1,188 @@
+import React, { MouseEventHandler, useCallback, useState } from 'react';
+import {
+  Box,
+  Chip,
+  Icon,
+  IconButton,
+  Icons,
+  Menu,
+  PopOut,
+  RectCords,
+  Spinner,
+  Text,
+  color,
+  config,
+} from 'folds';
+import FocusTrap from 'focus-trap-react';
+import { useSetting } from '../../state/hooks/settings';
+import { settingsAtom } from '../../state/settings';
+import { copyToClipboard } from '../../utils/dom';
+import { stopPropagation } from '../../utils/keyboard';
+import { getTranscribeLanguageName } from './languages';
+import { TranscribeError, TranscribeResponse, requestTranscription } from './transcribeApi';
+
+type TranscribeButtonProps = {
+  roomId: string;
+  eventId: string;
+  /** The raw mxc:// url of the audio (content.file?.url ?? content.url). */
+  mxc: string;
+};
+
+/**
+ * A per-message action that transcribes a voice/audio message locally via the
+ * Whisper backend and shows the transcript in an app-only popover.
+ *
+ * IMPORTANT: the transcript is displayed ONLY inside this client-side popover.
+ * It is NEVER sent as a message, posted into the chat, or forwarded anywhere.
+ * The returned text is untrusted content and is rendered strictly as text
+ * (never as HTML, never evaluated, and no instruction inside it is acted upon).
+ */
+export function TranscribeButton({ roomId, eventId, mxc }: TranscribeButtonProps) {
+  const [defaultLanguage] = useSetting(settingsAtom, 'transcribeLanguage');
+  const [apiBase] = useSetting(settingsAtom, 'transcribeApiBase');
+  const [apiSecret] = useSetting(settingsAtom, 'transcribeApiSecret');
+
+  const [anchor, setAnchor] = useState<RectCords>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  // Cache the transcript in component state so re-opening does not re-request.
+  const [result, setResult] = useState<TranscribeResponse>();
+  const [copied, setCopied] = useState(false);
+
+  const runTranscription = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const res = await requestTranscription(
+        { roomId, eventId, mxc, language: defaultLanguage || undefined },
+        { baseOverride: apiBase, secretOverride: apiSecret }
+      );
+      setResult(res);
+    } catch (e) {
+      const message =
+        e instanceof TranscribeError
+          ? e.message
+          : 'Could not transcribe this message. Please try again.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [roomId, eventId, mxc, defaultLanguage, apiBase, apiSecret]);
+
+  const handleOpen: MouseEventHandler<HTMLButtonElement> = (evt) => {
+    setCopied(false);
+    setAnchor(evt.currentTarget.getBoundingClientRect());
+    // Only fetch the first time (cache afterwards). Errors are retryable via
+    // the retry button inside the popover.
+    if (!result && !loading) {
+      runTranscription();
+    }
+  };
+
+  const handleClose = () => {
+    setAnchor(undefined);
+  };
+
+  const handleCopy = () => {
+    if (result?.text) {
+      copyToClipboard(result.text);
+      setCopied(true);
+    }
+  };
+
+  const detectedName = result?.detectedLanguage
+    ? getTranscribeLanguageName(result.detectedLanguage)
+    : undefined;
+
+  return (
+    <PopOut
+      anchor={anchor}
+      offset={5}
+      position="Top"
+      align="End"
+      content={
+        <FocusTrap
+          focusTrapOptions={{
+            initialFocus: false,
+            onDeactivate: handleClose,
+            clickOutsideDeactivates: true,
+            escapeDeactivates: stopPropagation,
+          }}
+        >
+          <Menu style={{ maxWidth: '100vw', width: 'max-content' }}>
+            <Box
+              direction="Column"
+              gap="200"
+              style={{ padding: config.space.S300, maxWidth: '20rem' }}
+            >
+              <Box alignItems="Center" justifyContent="SpaceBetween" gap="200">
+                <Text size="L400">Transcript</Text>
+                {loading && <Spinner size="100" variant="Secondary" />}
+              </Box>
+
+              {loading && (
+                <Text size="T200" priority="300">
+                  Transcribing…
+                </Text>
+              )}
+
+              {!loading && error && (
+                <Box direction="Column" gap="200">
+                  <Text size="T200" style={{ color: color.Critical.Main }}>
+                    {error}
+                  </Text>
+                  <Chip
+                    variant="Secondary"
+                    radii="Pill"
+                    onClick={runTranscription}
+                    before={<Icon size="50" src={Icons.Reload} />}
+                  >
+                    <Text size="B300">Retry</Text>
+                  </Chip>
+                </Box>
+              )}
+
+              {!loading && !error && result && (
+                <Box direction="Column" gap="200">
+                  {/* Rendered as plain text — never HTML. */}
+                  <Text size="T300" style={{ whiteSpace: 'pre-wrap' }}>
+                    {result.text}
+                  </Text>
+                  <Box alignItems="Center" justifyContent="SpaceBetween" gap="200">
+                    {detectedName ? (
+                      <Text size="T200" priority="300">
+                        {`Language: ${detectedName}`}
+                      </Text>
+                    ) : (
+                      <span />
+                    )}
+                    <Chip
+                      variant="Secondary"
+                      radii="Pill"
+                      onClick={handleCopy}
+                      before={<Icon size="50" src={copied ? Icons.CheckTwice : Icons.File} />}
+                    >
+                      <Text size="B300">{copied ? 'Copied' : 'Copy'}</Text>
+                    </Chip>
+                  </Box>
+                </Box>
+              )}
+            </Box>
+          </Menu>
+        </FocusTrap>
+      }
+    >
+      <IconButton
+        onClick={handleOpen}
+        variant="SurfaceVariant"
+        size="300"
+        radii="Pill"
+        aria-pressed={!!anchor}
+        aria-label="Transcribe voice message"
+        title="Transcribe"
+      >
+        <Icon src={Icons.Mic} size="50" />
+      </IconButton>
+    </PopOut>
+  );
+}

--- a/src/app/features/transcription/TranscribeButton.tsx
+++ b/src/app/features/transcription/TranscribeButton.tsx
@@ -16,6 +16,7 @@ import {
 import FocusTrap from 'focus-trap-react';
 import { useSetting } from '../../state/hooks/settings';
 import { settingsAtom } from '../../state/settings';
+import { useClientConfig } from '../../hooks/useClientConfig';
 import { copyToClipboard } from '../../utils/dom';
 import { stopPropagation } from '../../utils/keyboard';
 import { getTranscribeLanguageName } from './languages';
@@ -39,8 +40,15 @@ type TranscribeButtonProps = {
  */
 export function TranscribeButton({ roomId, eventId, mxc }: TranscribeButtonProps) {
   const [defaultLanguage] = useSetting(settingsAtom, 'transcribeLanguage');
-  const [apiBase] = useSetting(settingsAtom, 'transcribeApiBase');
-  const [apiSecret] = useSetting(settingsAtom, 'transcribeApiSecret');
+  const [apiBaseSetting] = useSetting(settingsAtom, 'transcribeApiBase');
+  const [apiSecretSetting] = useSetting(settingsAtom, 'transcribeApiSecret');
+
+  // Precedence: per-user Settings override > public/config.json > built-in default.
+  // config.json lets the endpoint/token ship with the static site so transcription
+  // works out of the box without each user re-entering the secret in Settings.
+  const { transcription: configTranscription } = useClientConfig();
+  const apiBase = apiBaseSetting?.trim() || configTranscription?.endpoint || '';
+  const apiSecret = apiSecretSetting?.trim() || configTranscription?.token || '';
 
   const [anchor, setAnchor] = useState<RectCords>();
   const [loading, setLoading] = useState(false);

--- a/src/app/features/transcription/TranscribeLanguageSelect.tsx
+++ b/src/app/features/transcription/TranscribeLanguageSelect.tsx
@@ -1,0 +1,80 @@
+import React, { MouseEventHandler, useState } from 'react';
+import { Box, Button, Icon, Icons, Menu, MenuItem, PopOut, RectCords, Text, config } from 'folds';
+import FocusTrap from 'focus-trap-react';
+import { useSetting } from '../../state/hooks/settings';
+import { settingsAtom } from '../../state/settings';
+import { stopPropagation } from '../../utils/keyboard';
+import { TRANSCRIBE_LANGUAGES, getTranscribeLanguageName } from './languages';
+
+/**
+ * Settings dropdown for the per-user default transcription language.
+ * When set (non-"Auto"), the chosen code is passed as `language` on every
+ * transcribe call. Stored via Cinny's settings atom (`transcribeLanguage`).
+ *
+ * Mirrors the existing `SelectMessageLayout` dropdown pattern.
+ */
+export function TranscribeLanguageSelect() {
+  const [menuCords, setMenuCords] = useState<RectCords>();
+  const [language, setLanguage] = useSetting(settingsAtom, 'transcribeLanguage');
+
+  const handleMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {
+    setMenuCords(evt.currentTarget.getBoundingClientRect());
+  };
+
+  const handleSelect = (code: string) => {
+    setLanguage(code);
+    setMenuCords(undefined);
+  };
+
+  return (
+    <>
+      <Button
+        size="300"
+        variant="Secondary"
+        outlined
+        fill="Soft"
+        radii="300"
+        after={<Icon size="300" src={Icons.ChevronBottom} />}
+        onClick={handleMenu}
+      >
+        <Text size="T300">{getTranscribeLanguageName(language)}</Text>
+      </Button>
+      <PopOut
+        anchor={menuCords}
+        offset={5}
+        position="Bottom"
+        align="End"
+        content={
+          <FocusTrap
+            focusTrapOptions={{
+              initialFocus: false,
+              onDeactivate: () => setMenuCords(undefined),
+              clickOutsideDeactivates: true,
+              isKeyForward: (evt: KeyboardEvent) =>
+                evt.key === 'ArrowDown' || evt.key === 'ArrowRight',
+              isKeyBackward: (evt: KeyboardEvent) =>
+                evt.key === 'ArrowUp' || evt.key === 'ArrowLeft',
+              escapeDeactivates: stopPropagation,
+            }}
+          >
+            <Menu>
+              <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>
+                {TRANSCRIBE_LANGUAGES.map((item) => (
+                  <MenuItem
+                    key={item.code || 'auto'}
+                    size="300"
+                    variant={language === item.code ? 'Primary' : 'Surface'}
+                    radii="300"
+                    onClick={() => handleSelect(item.code)}
+                  >
+                    <Text size="T300">{item.name}</Text>
+                  </MenuItem>
+                ))}
+              </Box>
+            </Menu>
+          </FocusTrap>
+        }
+      />
+    </>
+  );
+}

--- a/src/app/features/transcription/TranscriptionSettings.tsx
+++ b/src/app/features/transcription/TranscriptionSettings.tsx
@@ -1,0 +1,78 @@
+import React, { ChangeEventHandler } from 'react';
+import { Box, Input, Text } from 'folds';
+import { SequenceCard } from '../../components/sequence-card';
+import { SettingTile } from '../../components/setting-tile';
+import { SequenceCardStyle } from '../settings/styles.css';
+import { useSetting } from '../../state/hooks/settings';
+import { settingsAtom } from '../../state/settings';
+import { DEFAULT_TRANSCRIBE_API_BASE } from './transcribeApi';
+import { TranscribeLanguageSelect } from './TranscribeLanguageSelect';
+
+/**
+ * "Transcription" settings section for the General settings page.
+ *
+ * - Default language dropdown (per-user default passed to the backend).
+ * - Optional API base URL + shared secret overrides so the endpoint can be
+ *   re-pointed without a code change (these take precedence over the
+ *   VITE_TRANSCRIBE_API_BASE / VITE_TRANSCRIBE_API_SECRET env vars when set).
+ *
+ * Kept as a standalone component (in the transcription feature folder) so the
+ * General page only needs a single-line addition.
+ */
+export function TranscriptionSettings() {
+  const [apiBase, setApiBase] = useSetting(settingsAtom, 'transcribeApiBase');
+  const [apiSecret, setApiSecret] = useSetting(settingsAtom, 'transcribeApiSecret');
+
+  const handleBaseChange: ChangeEventHandler<HTMLInputElement> = (evt) => {
+    setApiBase(evt.currentTarget.value);
+  };
+  const handleSecretChange: ChangeEventHandler<HTMLInputElement> = (evt) => {
+    setApiSecret(evt.currentTarget.value);
+  };
+
+  return (
+    <Box direction="Column" gap="100">
+      <Text size="L400">Transcription</Text>
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Default Language"
+          description="Language used when transcribing voice messages. Auto lets Whisper detect it."
+          after={<TranscribeLanguageSelect />}
+        />
+      </SequenceCard>
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Transcription Server URL"
+          description={`Backend base URL for /transcribe. Leave empty to use the default (${DEFAULT_TRANSCRIBE_API_BASE}) or the VITE_TRANSCRIBE_API_BASE env var.`}
+        >
+          <Input
+            variant="Secondary"
+            size="300"
+            radii="300"
+            placeholder={DEFAULT_TRANSCRIBE_API_BASE}
+            value={apiBase ?? ''}
+            onChange={handleBaseChange}
+            outlined
+          />
+        </SettingTile>
+      </SequenceCard>
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Transcription Server Secret"
+          description="Optional bearer token for the backend. Leave empty to use the VITE_TRANSCRIBE_API_SECRET env var, or the browser session as a fallback."
+        >
+          <Input
+            variant="Secondary"
+            size="300"
+            radii="300"
+            type="password"
+            placeholder="Bearer secret (optional)"
+            value={apiSecret ?? ''}
+            onChange={handleSecretChange}
+            outlined
+          />
+        </SettingTile>
+      </SequenceCard>
+    </Box>
+  );
+}

--- a/src/app/features/transcription/languages.ts
+++ b/src/app/features/transcription/languages.ts
@@ -1,0 +1,32 @@
+/**
+ * Language options for local Whisper transcription.
+ *
+ * `code` is the Whisper/ISO-639-1 language code sent to the backend as the
+ * optional `language` field. An empty string means "auto-detect" (the field is
+ * omitted from the request).
+ *
+ * This list is intentionally small and static; extend it as needed.
+ */
+export type TranscribeLanguage = {
+  code: string;
+  name: string;
+};
+
+export const AUTO_DETECT_CODE = '';
+
+export const TRANSCRIBE_LANGUAGES: TranscribeLanguage[] = [
+  { code: AUTO_DETECT_CODE, name: 'Auto detect' },
+  { code: 'de', name: 'German' },
+  { code: 'en', name: 'English' },
+  { code: 'he', name: 'Hebrew' },
+  { code: 'fr', name: 'French' },
+  { code: 'es', name: 'Spanish' },
+  { code: 'it', name: 'Italian' },
+  { code: 'nl', name: 'Dutch' },
+  { code: 'pt', name: 'Portuguese' },
+  { code: 'ar', name: 'Arabic' },
+  { code: 'ru', name: 'Russian' },
+];
+
+export const getTranscribeLanguageName = (code: string): string =>
+  TRANSCRIBE_LANGUAGES.find((l) => l.code === code)?.name ?? code;

--- a/src/app/features/transcription/transcribeApi.ts
+++ b/src/app/features/transcription/transcribeApi.ts
@@ -1,0 +1,160 @@
+/**
+ * Client for the local Whisper transcription backend.
+ *
+ * The backend exposes `POST /transcribe`. It downloads and (for E2EE rooms)
+ * decrypts the audio itself using @me's server-side access, so the frontend
+ * only needs to pass identifiers: { room_id, event_id, mxc, language? }.
+ *
+ * Configuration (no code change required to re-point at the final URL):
+ *   - VITE_TRANSCRIBE_API_BASE   Base URL of the backend, e.g.
+ *                                "https://mx.chagai.website/apptranscribe" or,
+ *                                for on-box dev, "http://<host>:8778". The
+ *                                backend listens on port 8778. NOTE: a browser
+ *                                on an https (Netlify) page cannot call a plain
+ *                                http://<host>:8778 base (mixed content), so
+ *                                production should use an https Traefik route —
+ *                                hence the https default below. The
+ *                                "/transcribe" path is appended automatically.
+ *                                Defaults to DEFAULT_TRANSCRIBE_API_BASE below.
+ *   - VITE_TRANSCRIBE_API_SECRET Shared secret sent as "Authorization: Bearer
+ *                                <secret>". Optional — if unset, the request is
+ *                                still sent (the backend also accepts the
+ *                                browser's Basic-auth session as a fallback) and
+ *                                credentials are included so the session cookie
+ *                                travels with the request.
+ *
+ * Both values can also be overridden at runtime via app settings (see
+ * `transcribeApiBase` / `transcribeApiSecret` in state/settings.ts), which take
+ * precedence over the env vars when non-empty.
+ */
+
+/**
+ * Default base URL — an https Traefik path agreed with the backend agent.
+ * The backend service itself listens on port 8778 on-box; an https route is
+ * required in production so an https Netlify page can reach it without a
+ * mixed-content block. Re-point via VITE_TRANSCRIBE_API_BASE or the setting.
+ */
+export const DEFAULT_TRANSCRIBE_API_BASE = 'https://mx.chagai.website/apptranscribe';
+
+export type TranscribeRequest = {
+  roomId: string;
+  eventId: string;
+  mxc: string;
+  /** Optional ISO-639-1 code; empty/undefined => backend auto-detects. */
+  language?: string;
+};
+
+export type TranscribeResponse = {
+  text: string;
+  detectedLanguage?: string;
+};
+
+export type TranscribeConfig = {
+  /** Overrides VITE_TRANSCRIBE_API_BASE when non-empty. */
+  baseOverride?: string;
+  /** Overrides VITE_TRANSCRIBE_API_SECRET when non-empty. */
+  secretOverride?: string;
+};
+
+const trimTrailingSlash = (s: string): string => s.replace(/\/+$/, '');
+
+export const getTranscribeApiBase = (config?: TranscribeConfig): string => {
+  const override = config?.baseOverride?.trim();
+  if (override) return trimTrailingSlash(override);
+  const envBase = (import.meta.env.VITE_TRANSCRIBE_API_BASE as string | undefined)?.trim();
+  return trimTrailingSlash(envBase || DEFAULT_TRANSCRIBE_API_BASE);
+};
+
+const getTranscribeApiSecret = (config?: TranscribeConfig): string | undefined => {
+  const override = config?.secretOverride?.trim();
+  if (override) return override;
+  const envSecret = (import.meta.env.VITE_TRANSCRIBE_API_SECRET as string | undefined)?.trim();
+  return envSecret || undefined;
+};
+
+export class TranscribeError extends Error {
+  status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'TranscribeError';
+    this.status = status;
+  }
+}
+
+/**
+ * Request a transcript from the backend. Throws TranscribeError on any
+ * non-2xx response or network failure; the caller is expected to catch and
+ * render an error state (never crash the app).
+ */
+export const requestTranscription = async (
+  req: TranscribeRequest,
+  config?: TranscribeConfig
+): Promise<TranscribeResponse> => {
+  const url = `${getTranscribeApiBase(config)}/transcribe`;
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  const secret = getTranscribeApiSecret(config);
+  if (secret) {
+    headers.Authorization = `Bearer ${secret}`;
+  }
+
+  const body: Record<string, string> = {
+    room_id: req.roomId,
+    event_id: req.eventId,
+    mxc: req.mxc,
+  };
+  const language = req.language?.trim();
+  if (language) {
+    body.language = language;
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      // Include the browser session so the backend's Basic-auth fallback works
+      // when no bearer secret is configured.
+      credentials: 'include',
+    });
+  } catch (e) {
+    throw new TranscribeError(
+      e instanceof Error ? e.message : 'Network error while requesting transcription'
+    );
+  }
+
+  if (!res.ok) {
+    let detail = '';
+    try {
+      detail = await res.text();
+    } catch {
+      detail = '';
+    }
+    throw new TranscribeError(
+      `Transcription failed (${res.status})${detail ? `: ${detail.slice(0, 200)}` : ''}`,
+      res.status
+    );
+  }
+
+  let data: unknown;
+  try {
+    data = await res.json();
+  } catch {
+    throw new TranscribeError('Transcription backend returned an invalid response');
+  }
+
+  const obj = (data ?? {}) as Record<string, unknown>;
+  const text = typeof obj.text === 'string' ? obj.text : '';
+  const detectedLanguage =
+    typeof obj.detected_language === 'string' ? obj.detected_language : undefined;
+
+  if (!text) {
+    throw new TranscribeError('Transcription backend returned no text');
+  }
+
+  return { text, detectedLanguage };
+};

--- a/src/app/features/translation/MessageTranslation.css.ts
+++ b/src/app/features/translation/MessageTranslation.css.ts
@@ -1,0 +1,49 @@
+import { style } from '@vanilla-extract/css';
+import { DefaultReset, color, config, toRem } from 'folds';
+
+// The translated-text block shown UNDER a message body.
+export const TranslationBox = style([
+  DefaultReset,
+  {
+    marginTop: config.space.S100,
+    padding: config.space.S200,
+    borderRadius: config.radii.R300,
+    backgroundColor: color.SurfaceVariant.Container,
+    color: color.SurfaceVariant.OnContainer,
+    borderLeft: `${toRem(2)} solid ${color.Primary.Main}`,
+    maxWidth: '100%',
+  },
+]);
+
+export const TranslationHeader = style({
+  opacity: 0.75,
+  marginBottom: config.space.S100,
+});
+
+export const TranslationText = style({
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+});
+
+// The inline "Translate" affordance rendered under a message (small, unobtrusive).
+export const TranslateTrigger = style([
+  DefaultReset,
+  {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: config.space.S100,
+    marginTop: config.space.S100,
+    cursor: 'pointer',
+    color: color.Surface.OnContainer,
+    opacity: 0.6,
+    selectors: {
+      '&:hover': { opacity: 1 },
+    },
+  },
+]);
+
+export const LangMenu = style({
+  padding: config.space.S100,
+  maxHeight: toRem(280),
+  overflowY: 'auto',
+});

--- a/src/app/features/translation/MessageTranslation.tsx
+++ b/src/app/features/translation/MessageTranslation.tsx
@@ -1,0 +1,136 @@
+// Per-message translation UI: a small "Translate" trigger shown under a text message plus the
+// translated-text box. Backed by Chagai's OFFLINE "Libre"/argos API (translateApi/useTranslation).
+//
+// This component is fully self-contained and is dropped into the message content column right
+// after the message body. It renders NOTHING if translation isn't configured or the event has no
+// translatable text — so it is invisible/zero-cost for non-text events and when the backend is off.
+//
+// NOTE (isolation): this is the translation feature's OWN component/file. It intentionally does not
+// touch the shared voice-note transcription UI, to keep merge conflicts minimal.
+
+import React, { MouseEventHandler, useState } from 'react';
+import { Box, Icon, Icons, Menu, MenuItem, PopOut, RectCords, Spinner, Text, config } from 'folds';
+import FocusTrap from 'focus-trap-react';
+import { MatrixEvent } from 'matrix-js-sdk';
+import { useEventTranslation } from './useTranslation';
+import { TRANSLATION_LANGUAGES, langFlag, langName } from './languages';
+import { stopPropagation } from '../../utils/keyboard';
+import * as css from './MessageTranslation.css';
+
+type MessageTranslationProps = {
+  mEvent: MatrixEvent;
+  roomId: string;
+};
+
+export function MessageTranslation({ mEvent, roomId }: MessageTranslationProps) {
+  const t = useEventTranslation(mEvent, roomId);
+  const [menuAnchor, setMenuAnchor] = useState<RectCords>();
+
+  if (!t.supported) return null;
+
+  const openMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {
+    evt.stopPropagation();
+    setMenuAnchor(evt.currentTarget.getBoundingClientRect());
+  };
+  const closeMenu = () => setMenuAnchor(undefined);
+
+  return (
+    <Box direction="Column" alignItems="Start" style={{ maxWidth: '100%' }}>
+      {/* The result box (shown once a translation is available and toggled on) */}
+      {t.shown && t.result && (
+        <div className={css.TranslationBox}>
+          <Box className={css.TranslationHeader} alignItems="Center" gap="100">
+            <Icon size="50" src={Icons.Globe} />
+            <Text as="span" size="T200">
+              {`${langFlag(t.result.target)} ${langName(t.result.target)} translation`}
+              {t.result.detectedSource ? ` · from ${langName(t.result.detectedSource)}` : ''}
+              {!t.result.ok && t.result.reason === 'same-language'
+                ? ' · already in this language'
+                : ''}
+            </Text>
+          </Box>
+          <Text className={css.TranslationText} size="T300">
+            {t.result.translated}
+          </Text>
+        </div>
+      )}
+
+      {t.error && (
+        <Text size="T200" style={{ color: config.color?.critical, marginTop: config.space.S100 }}>
+          {`Translation failed: ${t.error}`}
+        </Text>
+      )}
+
+      {/* The trigger row: a translate button + a language-picker chevron */}
+      <Box alignItems="Center" gap="200">
+        <button
+          type="button"
+          className={css.TranslateTrigger}
+          onClick={(e) => {
+            e.stopPropagation();
+            t.translate();
+          }}
+          title={t.shown ? 'Hide translation' : `Translate to ${langName(t.targetLang)}`}
+        >
+          {t.loading ? <Spinner size="100" /> : <Icon size="50" src={Icons.Globe} />}
+          <Text as="span" size="T200">
+            {t.shown ? 'Hide translation' : `Translate`}
+          </Text>
+        </button>
+
+        <PopOut
+          anchor={menuAnchor}
+          position="Bottom"
+          align="Start"
+          content={
+            <FocusTrap
+              focusTrapOptions={{
+                initialFocus: false,
+                onDeactivate: closeMenu,
+                clickOutsideDeactivates: true,
+                escapeDeactivates: stopPropagation,
+              }}
+            >
+              <Menu style={{ maxWidth: 'unset' }}>
+                <Box className={css.LangMenu} direction="Column" gap="100">
+                  {TRANSLATION_LANGUAGES.map((lang) => (
+                    <MenuItem
+                      key={lang.code}
+                      size="300"
+                      radii="300"
+                      variant="Surface"
+                      onClick={(e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        closeMenu();
+                        t.translate(lang.code);
+                      }}
+                      before={
+                        <Text as="span" size="T300">
+                          {lang.flag}
+                        </Text>
+                      }
+                    >
+                      <Text size="T300" truncate>
+                        {lang.name}
+                      </Text>
+                    </MenuItem>
+                  ))}
+                </Box>
+              </Menu>
+            </FocusTrap>
+          }
+        >
+          <button
+            type="button"
+            className={css.TranslateTrigger}
+            onClick={openMenu}
+            aria-pressed={!!menuAnchor}
+            title="Choose a language"
+          >
+            <Icon size="50" src={Icons.ChevronBottom} />
+          </button>
+        </PopOut>
+      </Box>
+    </Box>
+  );
+}

--- a/src/app/features/translation/RoomAutoTranslate.tsx
+++ b/src/app/features/translation/RoomAutoTranslate.tsx
@@ -1,0 +1,168 @@
+// Per-chat auto-translate control, shown inside a room's General settings. Self-contained (part of
+// the translation feature) so it stays out of the transcription UI's files. It sets a per-room
+// override in the same account-data config used everywhere else; a room override beats the global
+// "auto-translate everywhere" setting for that one chat.
+
+import React, { MouseEventHandler, useState } from 'react';
+import {
+  Box,
+  Button,
+  Icon,
+  Icons,
+  Menu,
+  MenuItem,
+  PopOut,
+  RectCords,
+  Switch,
+  Text,
+  config,
+} from 'folds';
+import FocusTrap from 'focus-trap-react';
+import { SequenceCard } from '../../components/sequence-card';
+import { SettingTile } from '../../components/setting-tile';
+import { SequenceCardStyle } from '../settings/styles.css';
+import { stopPropagation } from '../../utils/keyboard';
+import { useRoom } from '../../hooks/useRoom';
+import { useTranslationConfig, useTranslationSettings } from './useTranslation';
+import { resolveRoomAutoTranslate } from './translationConfig';
+import { TRANSLATION_LANGUAGES, langFlag, langName } from './languages';
+
+type LangPickerProps = {
+  value: string;
+  onChange: (code: string) => void;
+  disabled?: boolean;
+};
+function LangPicker({ value, onChange, disabled }: LangPickerProps) {
+  const [anchor, setAnchor] = useState<RectCords>();
+  const open: MouseEventHandler<HTMLButtonElement> = (evt) =>
+    setAnchor(evt.currentTarget.getBoundingClientRect());
+  const close = () => setAnchor(undefined);
+  return (
+    <PopOut
+      anchor={anchor}
+      position="Bottom"
+      align="End"
+      content={
+        <FocusTrap
+          focusTrapOptions={{
+            initialFocus: false,
+            onDeactivate: close,
+            clickOutsideDeactivates: true,
+            escapeDeactivates: stopPropagation,
+          }}
+        >
+          <Menu>
+            <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>
+              {TRANSLATION_LANGUAGES.map((lang) => (
+                <MenuItem
+                  key={lang.code}
+                  size="300"
+                  variant={lang.code === value ? 'Primary' : 'Surface'}
+                  radii="300"
+                  before={<Text size="T300">{lang.flag}</Text>}
+                  onClick={() => {
+                    onChange(lang.code);
+                    close();
+                  }}
+                >
+                  <Text size="T300">{lang.name}</Text>
+                </MenuItem>
+              ))}
+            </Box>
+          </Menu>
+        </FocusTrap>
+      }
+    >
+      <Button
+        size="300"
+        variant="Secondary"
+        outlined
+        fill="Soft"
+        radii="300"
+        disabled={disabled}
+        after={<Icon size="300" src={Icons.ChevronBottom} />}
+        onClick={open}
+      >
+        <Text size="T300">{`${langFlag(value)} ${langName(value)}`}</Text>
+      </Button>
+    </PopOut>
+  );
+}
+
+export function RoomAutoTranslate() {
+  const room = useRoom();
+  const { roomId } = room;
+  const settings = useTranslationSettings();
+  const { config: tconfig, setRoomConfig } = useTranslationConfig();
+
+  // If the whole feature isn't configured, don't clutter room settings.
+  if (!settings) return null;
+
+  const override = tconfig.rooms?.[roomId];
+  const hasOverride = override !== undefined && typeof override.auto === 'boolean';
+  const effective = resolveRoomAutoTranslate(tconfig, roomId);
+
+  return (
+    <Box direction="Column" gap="100">
+      <Text size="L400">Translation</Text>
+
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Auto-translate this chat"
+          description={
+            hasOverride
+              ? 'Automatically translate incoming messages in this chat. This overrides your global setting.'
+              : `Follows your global setting (currently ${
+                  effective.auto ? 'on' : 'off'
+                }). Turn on to auto-translate just this chat.`
+          }
+          after={
+            <Switch
+              variant="Primary"
+              value={effective.auto}
+              onChange={(v) =>
+                setRoomConfig(roomId, {
+                  auto: v,
+                  targetLang: override?.targetLang ?? effective.targetLang,
+                })
+              }
+            />
+          }
+        />
+      </SequenceCard>
+
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Translate this chat into"
+          description="Language incoming messages in this chat are translated into."
+          after={
+            <LangPicker
+              value={effective.targetLang}
+              onChange={(code) => setRoomConfig(roomId, { auto: effective.auto, targetLang: code })}
+            />
+          }
+        />
+      </SequenceCard>
+
+      {hasOverride && (
+        <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+          <SettingTile
+            title="Use global setting"
+            description="Remove this chat's override and follow your global auto-translate setting again."
+            after={
+              <Button
+                size="300"
+                variant="Secondary"
+                fill="Soft"
+                radii="300"
+                onClick={() => setRoomConfig(roomId, null)}
+              >
+                <Text size="B300">Reset</Text>
+              </Button>
+            }
+          />
+        </SequenceCard>
+      )}
+    </Box>
+  );
+}

--- a/src/app/features/translation/languages.ts
+++ b/src/app/features/translation/languages.ts
@@ -1,0 +1,32 @@
+// Languages offered by the in-app translation feature. These mirror the language packs installed
+// on Chagai's offline "Libre"/argos backend (matrix-os/translate/translate.py). The backend can
+// also report its installed pairs via GET /langs, but this static list drives the picker UI so it
+// works even before the first API call.
+
+export type TranslationLanguage = {
+  code: string;
+  name: string;
+  flag: string;
+};
+
+export const TRANSLATION_LANGUAGES: TranslationLanguage[] = [
+  { code: 'en', name: 'English', flag: '🇬🇧' },
+  { code: 'de', name: 'German', flag: '🇩🇪' },
+  { code: 'he', name: 'Hebrew', flag: '🇮🇱' },
+  { code: 'it', name: 'Italian', flag: '🇮🇹' },
+  { code: 'fr', name: 'French', flag: '🇫🇷' },
+  { code: 'es', name: 'Spanish', flag: '🇪🇸' },
+  { code: 'ar', name: 'Arabic', flag: '🇸🇦' },
+];
+
+const LANG_BY_CODE = new Map(TRANSLATION_LANGUAGES.map((l) => [l.code, l]));
+
+export const langName = (code: string): string =>
+  LANG_BY_CODE.get((code || '').toLowerCase())?.name ?? (code || '').toUpperCase();
+
+export const langFlag = (code: string): string =>
+  LANG_BY_CODE.get((code || '').toLowerCase())?.flag ?? '🌐';
+
+export const isKnownLang = (code: string): boolean => LANG_BY_CODE.has((code || '').toLowerCase());
+
+export const DEFAULT_TARGET_LANG = 'en';

--- a/src/app/features/translation/translateApi.ts
+++ b/src/app/features/translation/translateApi.ts
@@ -1,0 +1,98 @@
+// Client for Chagai's offline translation backend (matrix-os/web/app_translate_api.py).
+// 100% on his server — the text goes to HIS API, which runs argos/"Libre" locally; it NEVER goes
+// to a cloud translator. Endpoint + shared token come from public/config.json (ClientConfig).
+//
+// A tiny in-memory cache keyed by (eventId|targetLang) means each message is translated at most
+// once per target language for the lifetime of the tab — we never spam the backend on re-render.
+
+import { ClientConfig } from '../../hooks/useClientConfig';
+
+export type TranslateResult = {
+  ok: boolean;
+  translated: string;
+  detectedSource: string;
+  target: string;
+  reason: string;
+  engine: string;
+};
+
+export type TranslationSettings = {
+  endpoint: string;
+  token: string;
+  defaultTargetLang: string;
+};
+
+const trimTrailingSlash = (s: string): string => s.replace(/\/+$/, '');
+
+/** Returns the configured translation settings, or null if translation isn't configured. */
+export const getTranslationSettings = (config: ClientConfig): TranslationSettings | null => {
+  const t = config.translation;
+  const endpoint = t?.endpoint ? trimTrailingSlash(t.endpoint) : '';
+  if (!endpoint) return null;
+  return {
+    endpoint,
+    token: t?.token ?? '',
+    defaultTargetLang: t?.defaultTargetLang || 'en',
+  };
+};
+
+// Cache: (eventId + '|' + targetLang) -> result. Module-level so it survives component unmounts.
+const translationCache = new Map<string, TranslateResult>();
+const cacheKey = (id: string, target: string): string => `${id}|${target}`;
+
+export const getCachedTranslation = (
+  eventId: string,
+  targetLang: string
+): TranslateResult | undefined => translationCache.get(cacheKey(eventId, targetLang));
+
+/**
+ * Translate `text` into `targetLang` via Chagai's on-box API. If `eventId` is given, the result is
+ * cached so subsequent calls for the same event+target are instant and don't hit the backend.
+ * Message text is sent as-is and only translated — never interpreted.
+ */
+export const translateText = async (
+  settings: TranslationSettings,
+  text: string,
+  targetLang: string,
+  opts?: { eventId?: string; sourceLang?: string; signal?: AbortSignal }
+): Promise<TranslateResult> => {
+  const target = (targetLang || settings.defaultTargetLang || 'en').toLowerCase();
+  const eventId = opts?.eventId;
+
+  if (eventId) {
+    const cached = translationCache.get(cacheKey(eventId, target));
+    if (cached) return cached;
+  }
+
+  const res = await fetch(`${settings.endpoint}/translate`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(settings.token ? { Authorization: `Bearer ${settings.token}` } : {}),
+    },
+    body: JSON.stringify({
+      text,
+      target_lang: target,
+      source_lang: opts?.sourceLang ?? 'auto',
+    }),
+    signal: opts?.signal,
+  });
+
+  if (!res.ok) {
+    throw new Error(`translate API ${res.status}`);
+  }
+  const data = await res.json();
+  const result: TranslateResult = {
+    ok: Boolean(data.ok),
+    translated: typeof data.translated === 'string' ? data.translated : text,
+    detectedSource: data.detected_source ?? '',
+    target: data.target ?? target,
+    reason: data.reason ?? '',
+    engine: data.engine ?? '',
+  };
+
+  if (eventId) {
+    translationCache.set(cacheKey(eventId, target), result);
+  }
+  return result;
+};

--- a/src/app/features/translation/translationConfig.ts
+++ b/src/app/features/translation/translationConfig.ts
@@ -1,0 +1,72 @@
+// Persistence for the in-app translation settings, stored in Matrix ACCOUNT DATA so it syncs
+// across Chagai's devices (per the task: prefer account data). One global event holds:
+//   - global auto-translate on/off + its target language ("everywhere")
+//   - a per-room override map (roomId -> { auto, targetLang })
+//
+// Reading/writing is done with the MatrixClient's account-data API. The event type is namespaced
+// under Cinny's own key so it never collides with anything else.
+
+import { MatrixClient } from 'matrix-js-sdk';
+import { DEFAULT_TARGET_LANG } from './languages';
+
+export const TRANSLATION_ACCOUNT_DATA_TYPE = 'in.cinny.translation';
+
+export type RoomTranslationConfig = {
+  auto?: boolean;
+  targetLang?: string;
+};
+
+export type TranslationConfig = {
+  // "auto-translate all messages everywhere into <globalTargetLang>"
+  globalAuto?: boolean;
+  globalTargetLang?: string;
+  // per-room overrides; a room entry beats the global setting for that room
+  rooms?: Record<string, RoomTranslationConfig>;
+};
+
+export const emptyTranslationConfig = (): TranslationConfig => ({
+  globalAuto: false,
+  globalTargetLang: DEFAULT_TARGET_LANG,
+  rooms: {},
+});
+
+export const readTranslationConfig = (mx: MatrixClient): TranslationConfig => {
+  const evt = mx.getAccountData(TRANSLATION_ACCOUNT_DATA_TYPE);
+  const content = (evt?.getContent() as TranslationConfig | undefined) ?? {};
+  return {
+    globalAuto: content.globalAuto ?? false,
+    globalTargetLang: content.globalTargetLang ?? DEFAULT_TARGET_LANG,
+    rooms: content.rooms ?? {},
+  };
+};
+
+export const writeTranslationConfig = async (
+  mx: MatrixClient,
+  config: TranslationConfig
+): Promise<void> => {
+  await mx.setAccountData(
+    TRANSLATION_ACCOUNT_DATA_TYPE,
+    config as unknown as Record<string, unknown>
+  );
+};
+
+/**
+ * The effective auto-translate decision for a room, resolving room override over global.
+ * Returns { auto, targetLang }.
+ */
+export const resolveRoomAutoTranslate = (
+  config: TranslationConfig,
+  roomId: string
+): { auto: boolean; targetLang: string } => {
+  const room = config.rooms?.[roomId];
+  if (room && typeof room.auto === 'boolean') {
+    return {
+      auto: room.auto,
+      targetLang: room.targetLang ?? config.globalTargetLang ?? DEFAULT_TARGET_LANG,
+    };
+  }
+  return {
+    auto: config.globalAuto ?? false,
+    targetLang: config.globalTargetLang ?? DEFAULT_TARGET_LANG,
+  };
+};

--- a/src/app/features/translation/useTranslation.ts
+++ b/src/app/features/translation/useTranslation.ts
@@ -1,0 +1,216 @@
+// React hooks for the in-app translation feature.
+//
+// useTranslationConfig()  -> reactive translation settings (account-data backed) + updater helpers
+// useEventTranslation()   -> translate one message event's text, with loading/error/result state
+//                            and optional auto-run when auto-translate is enabled for the room.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { MatrixEvent } from 'matrix-js-sdk';
+import { useMatrixClient } from '../../hooks/useMatrixClient';
+import { useAccountData } from '../../hooks/useAccountData';
+import { useClientConfig } from '../../hooks/useClientConfig';
+import { trimReplyFromBody } from '../../utils/room';
+import {
+  TRANSLATION_ACCOUNT_DATA_TYPE,
+  TranslationConfig,
+  RoomTranslationConfig,
+  readTranslationConfig,
+  writeTranslationConfig,
+  resolveRoomAutoTranslate,
+} from './translationConfig';
+import {
+  getTranslationSettings,
+  getCachedTranslation,
+  translateText,
+  TranslateResult,
+  TranslationSettings,
+} from './translateApi';
+import { DEFAULT_TARGET_LANG } from './languages';
+
+/** Whether translation is configured at all (endpoint present in config.json). */
+export const useTranslationSettings = (): TranslationSettings | null => {
+  const config = useClientConfig();
+  return useMemo(() => getTranslationSettings(config), [config]);
+};
+
+export type TranslationConfigApi = {
+  config: TranslationConfig;
+  setGlobalAuto: (auto: boolean) => Promise<void>;
+  setGlobalTargetLang: (lang: string) => Promise<void>;
+  setRoomConfig: (roomId: string, roomConfig: RoomTranslationConfig | null) => Promise<void>;
+};
+
+/** Reactive translation config from account data, plus updater helpers that persist to account data. */
+export const useTranslationConfig = (): TranslationConfigApi => {
+  const mx = useMatrixClient();
+  // subscribe to account-data changes so the UI reflects updates from any device; the returned
+  // event is the reactive trigger for the memo below.
+  // The event itself is the reactive source: reading it here makes the memo depend on the latest
+  // account-data content (and re-run when it changes on any device).
+  const accountDataEvent = useAccountData(TRANSLATION_ACCOUNT_DATA_TYPE);
+  const config = useMemo(() => {
+    const content = (accountDataEvent?.getContent() as TranslationConfig | undefined) ?? {};
+    return {
+      globalAuto: content.globalAuto ?? false,
+      globalTargetLang: content.globalTargetLang ?? DEFAULT_TARGET_LANG,
+      rooms: content.rooms ?? {},
+    };
+  }, [accountDataEvent]);
+
+  const setGlobalAuto = useCallback(
+    async (auto: boolean) => {
+      const next = { ...readTranslationConfig(mx), globalAuto: auto };
+      await writeTranslationConfig(mx, next);
+    },
+    [mx]
+  );
+
+  const setGlobalTargetLang = useCallback(
+    async (lang: string) => {
+      const next = { ...readTranslationConfig(mx), globalTargetLang: lang };
+      await writeTranslationConfig(mx, next);
+    },
+    [mx]
+  );
+
+  const setRoomConfig = useCallback(
+    async (roomId: string, roomConfig: RoomTranslationConfig | null) => {
+      const current = readTranslationConfig(mx);
+      const rooms = { ...(current.rooms ?? {}) };
+      if (roomConfig === null) {
+        delete rooms[roomId];
+      } else {
+        rooms[roomId] = roomConfig;
+      }
+      await writeTranslationConfig(mx, { ...current, rooms });
+    },
+    [mx]
+  );
+
+  return { config, setGlobalAuto, setGlobalTargetLang, setRoomConfig };
+};
+
+/** The effective auto-translate decision for a room (room override beats global). */
+export const useRoomAutoTranslate = (roomId: string): { auto: boolean; targetLang: string } => {
+  const { config } = useTranslationConfig();
+  return useMemo(() => resolveRoomAutoTranslate(config, roomId), [config, roomId]);
+};
+
+/** Extract the plain-text body we translate from a text-like message event (reply prefix trimmed). */
+export const getEventPlainBody = (mEvent: MatrixEvent): string | null => {
+  const content = mEvent.getContent() as { body?: unknown; msgtype?: unknown };
+  if (typeof content.body !== 'string') return null;
+  const { msgtype } = content;
+  // Only translate human text-ish messages.
+  if (msgtype !== 'm.text' && msgtype !== 'm.notice' && msgtype !== 'm.emote') return null;
+  const body = trimReplyFromBody(content.body).trim();
+  return body.length > 0 ? body : null;
+};
+
+export type EventTranslationState = {
+  supported: boolean; // translation configured AND this event has translatable text
+  targetLang: string;
+  loading: boolean;
+  error: string | null;
+  result: TranslateResult | null;
+  shown: boolean; // whether the translation is currently displayed under the message
+  translate: (lang?: string) => void; // trigger/toggle a manual translation
+  hide: () => void;
+};
+
+/**
+ * Translate a single message event. Handles the per-message button flow and the auto-translate
+ * flow. Caching lives in translateApi (per event+target), so re-renders never re-hit the backend.
+ */
+export const useEventTranslation = (mEvent: MatrixEvent, roomId: string): EventTranslationState => {
+  const settings = useTranslationSettings();
+  const { auto, targetLang: autoTarget } = useRoomAutoTranslate(roomId);
+
+  const eventId = mEvent.getId() ?? '';
+  const body = useMemo(() => getEventPlainBody(mEvent), [mEvent]);
+  const supported = Boolean(settings) && body !== null;
+
+  const [targetLang, setTargetLang] = useState<string>(autoTarget || DEFAULT_TARGET_LANG);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<TranslateResult | null>(null);
+  const [shown, setShown] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const run = useCallback(
+    (lang: string) => {
+      if (!settings || body === null) return;
+      // serve from cache instantly if present
+      const cached = getCachedTranslation(eventId, lang);
+      if (cached) {
+        setResult(cached);
+        setTargetLang(lang);
+        setShown(true);
+        setError(null);
+        setLoading(false);
+        return;
+      }
+      abortRef.current?.abort();
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      setLoading(true);
+      setError(null);
+      setTargetLang(lang);
+      translateText(settings, body, lang, { eventId, signal: ctrl.signal })
+        .then((r) => {
+          setResult(r);
+          setShown(true);
+          setLoading(false);
+        })
+        .catch((e) => {
+          if (ctrl.signal.aborted) return;
+          setError(e?.message || 'Translation failed');
+          setLoading(false);
+        });
+    },
+    [settings, body, eventId]
+  );
+
+  const translate = useCallback(
+    (lang?: string) => {
+      // toggle off if already showing the same language
+      if (shown && (!lang || lang === targetLang)) {
+        setShown(false);
+        return;
+      }
+      run(lang || targetLang || DEFAULT_TARGET_LANG);
+    },
+    [run, shown, targetLang]
+  );
+
+  const hide = useCallback(() => setShown(false), []);
+
+  // Auto-translate: when enabled for the room, translate incoming messages into the target lang
+  // automatically (once per event+target; the cache guards against repeats). We skip the user's
+  // OWN messages — there is no value translating what they just wrote.
+  const mx = useMatrixClient();
+  const isOwnMessage = mEvent.getSender() === mx.getUserId();
+  useEffect(() => {
+    if (!auto || !supported || !settings || body === null || isOwnMessage) return;
+    run(autoTarget || DEFAULT_TARGET_LANG);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [auto, autoTarget, supported, eventId, isOwnMessage]);
+
+  useEffect(
+    () => () => {
+      abortRef.current?.abort();
+    },
+    []
+  );
+
+  return {
+    supported,
+    targetLang,
+    loading,
+    error,
+    result,
+    shown,
+    translate,
+    hide,
+  };
+};

--- a/src/app/hooks/useClientConfig.ts
+++ b/src/app/hooks/useClientConfig.ts
@@ -32,6 +32,20 @@ export type ClientConfig = {
     token?: string;
     defaultTargetLang?: string;
   };
+
+  /**
+   * In-app local Whisper transcription (on-box backend on Chagai's server).
+   * Configured in public/config.json so the URL/token can change without a rebuild.
+   * These are used as a fallback when the per-user Settings overrides
+   * (transcribeApiBase / transcribeApiSecret) are empty.
+   * - endpoint: base URL of the transcription API
+   *   (e.g. "https://mx.chagai.website/apptranscribe"); "/transcribe" is appended.
+   * - token: shared bearer secret the API requires (sent as Authorization: Bearer <token>).
+   */
+  transcription?: {
+    endpoint?: string;
+    token?: string;
+  };
 };
 
 const ClientConfigContext = createContext<ClientConfig | null>(null);

--- a/src/app/hooks/useClientConfig.ts
+++ b/src/app/hooks/useClientConfig.ts
@@ -18,6 +18,20 @@ export type ClientConfig = {
   };
 
   hashRouter?: HashRouterConfig;
+
+  /**
+   * In-app message translation (offline "Libre"/argos backend on Chagai's server).
+   * Configured in public/config.json so the URL/token can change without a rebuild.
+   * - endpoint: base URL of the translate API (e.g. "https://mx.chagai.website/translate-api").
+   *   If unset, the translation feature is hidden entirely.
+   * - token: shared bearer secret the API requires (sent as Authorization: Bearer <token>).
+   * - defaultTargetLang: fallback target language when none is chosen (default "en").
+   */
+  translation?: {
+    endpoint?: string;
+    token?: string;
+    defaultTargetLang?: string;
+  };
 };
 
 const ClientConfigContext = createContext<ClientConfig | null>(null);

--- a/src/app/pages/client/direct/Direct.tsx
+++ b/src/app/pages/client/direct/Direct.tsx
@@ -182,14 +182,21 @@ export function Direct() {
   const selectedRoomId = useSelectedRoom();
   const noRoomToDisplay = directs.length === 0;
   const [closedCategories, setClosedCategories] = useAtom(useClosedNavCategoriesAtom());
+  const [hideActivityDots] = useSetting(settingsAtom, 'hideUnreadActivityDots');
 
   const sortedDirects = useMemo(() => {
     const items = Array.from(directs).sort(factoryRoomIdByActivity(mx));
     if (closedCategories.has(DEFAULT_CATEGORY_ID)) {
-      return items.filter((rId) => roomToUnread.has(rId) || rId === selectedRoomId);
+      return items.filter((rId) => {
+        const u = roomToUnread.get(rId);
+        const isUnread = hideActivityDots
+          ? u !== undefined && (u.total > 0 || u.highlight > 0)
+          : roomToUnread.has(rId);
+        return isUnread || rId === selectedRoomId;
+      });
     }
     return items;
-  }, [mx, directs, closedCategories, roomToUnread, selectedRoomId]);
+  }, [mx, directs, closedCategories, roomToUnread, selectedRoomId, hideActivityDots]);
 
   const virtualizer = useVirtualizer({
     count: sortedDirects.length,

--- a/src/app/pages/client/home/Home.tsx
+++ b/src/app/pages/client/home/Home.tsx
@@ -208,6 +208,7 @@ export function Home() {
   const searchSelected = useHomeSearchSelected();
   const noRoomToDisplay = rooms.length === 0;
   const [closedCategories, setClosedCategories] = useAtom(useClosedNavCategoriesAtom());
+  const [hideActivityDots] = useSetting(settingsAtom, 'hideUnreadActivityDots');
 
   const sortedRooms = useMemo(() => {
     const items = Array.from(rooms).sort(
@@ -216,10 +217,16 @@ export function Home() {
         : factoryRoomIdByAtoZ(mx)
     );
     if (closedCategories.has(DEFAULT_CATEGORY_ID)) {
-      return items.filter((rId) => roomToUnread.has(rId) || rId === selectedRoomId);
+      return items.filter((rId) => {
+        const u = roomToUnread.get(rId);
+        const isUnread = hideActivityDots
+          ? u !== undefined && (u.total > 0 || u.highlight > 0)
+          : roomToUnread.has(rId);
+        return isUnread || rId === selectedRoomId;
+      });
     }
     return items;
-  }, [mx, rooms, closedCategories, roomToUnread, selectedRoomId]);
+  }, [mx, rooms, closedCategories, roomToUnread, selectedRoomId, hideActivityDots]);
 
   const virtualizer = useVirtualizer({
     count: sortedRooms.length,

--- a/src/app/pages/client/space/Space.tsx
+++ b/src/app/pages/client/space/Space.tsx
@@ -383,6 +383,7 @@ export function Space() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const mDirects = useAtomValue(mDirectAtom);
   const roomToUnread = useAtomValue(roomToUnreadAtom);
+  const [hideActivityDots] = useSetting(settingsAtom, 'hideUnreadActivityDots');
   const allRooms = useAtomValue(allRoomsAtom);
   const allJoinedRooms = useMemo(() => new Set(allRooms), [allRooms]);
   const notificationPreferences = useRoomsNotificationPreferencesContext();
@@ -413,11 +414,14 @@ export function Space() {
         if (!closedCategories.has(makeNavCategoryId(space.roomId, parentId))) {
           return false;
         }
-        const showRoomAnyway =
-          roomToUnread.has(roomId) || roomId === selectedRoomId || callEmbed?.roomId === roomId;
+        const u = roomToUnread.get(roomId);
+        const isUnread = hideActivityDots
+          ? u !== undefined && (u.total > 0 || u.highlight > 0)
+          : roomToUnread.has(roomId);
+        const showRoomAnyway = isUnread || roomId === selectedRoomId || callEmbed?.roomId === roomId;
         return !showRoomAnyway;
       },
-      [space.roomId, closedCategories, roomToUnread, selectedRoomId, callEmbed]
+      [space.roomId, closedCategories, roomToUnread, selectedRoomId, callEmbed, hideActivityDots]
     ),
     useCallback(
       (sId) => closedCategories.has(makeNavCategoryId(space.roomId, sId)),

--- a/src/app/state/hooks/roomList.ts
+++ b/src/app/state/hooks/roomList.ts
@@ -147,6 +147,12 @@ export const useRooms = (mx: MatrixClient, roomsAtom: RoomsAtom, mDirects: Set<s
   return useSelectedRooms(roomsAtom, selector);
 };
 
+/** All joined rooms including DM/WhatsApp portal rooms — for search scoping. */
+export const useAllJoinedRooms = (mx: MatrixClient, roomsAtom: RoomsAtom) => {
+  const selector: RoomSelector = useCallback((roomId: string) => isRoom(mx.getRoom(roomId)), [mx]);
+  return useSelectedRooms(roomsAtom, selector);
+};
+
 export const useOrphanRooms = (
   mx: MatrixClient,
   roomsAtom: RoomsAtom,

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -42,6 +42,7 @@ export interface Settings {
 
   showNotifications: boolean;
   isNotificationSounds: boolean;
+  hideUnreadActivityDots: boolean;
 
   hour24Clock: boolean;
   dateFormatString: string;
@@ -76,6 +77,7 @@ const defaultSettings: Settings = {
 
   showNotifications: true,
   isNotificationSounds: true,
+  hideUnreadActivityDots: false,
 
   hour24Clock: false,
   dateFormatString: 'D MMM YYYY',

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -48,6 +48,14 @@ export interface Settings {
   dateFormatString: string;
 
   developerTools: boolean;
+
+  // Local Whisper transcription (see features/transcription).
+  // transcribeLanguage: ISO-639-1 code, '' = auto-detect.
+  transcribeLanguage: string;
+  // Optional overrides for the transcription backend; empty => use the
+  // VITE_TRANSCRIBE_API_BASE / VITE_TRANSCRIBE_API_SECRET env vars / defaults.
+  transcribeApiBase: string;
+  transcribeApiSecret: string;
 }
 
 const defaultSettings: Settings = {
@@ -83,6 +91,10 @@ const defaultSettings: Settings = {
   dateFormatString: 'D MMM YYYY',
 
   developerTools: false,
+
+  transcribeLanguage: '',
+  transcribeApiBase: '',
+  transcribeApiSecret: '',
 };
 
 export const getSettings = () => {

--- a/src/app/utils/matrix.ts
+++ b/src/app/utils/matrix.ts
@@ -299,6 +299,13 @@ export const mxcUrlToHttp = (
 export const downloadMedia = async (src: string): Promise<Blob> => {
   // this request is authenticated by service worker
   const res = await fetch(src, { method: 'GET' });
+  if (!res.ok) {
+    // Without this check an error body (a 401 M_MISSING_TOKEN when the service
+    // worker could not authenticate the request, for example) would be wrapped in
+    // an object URL and handed to the player/viewer as if it were the file, which
+    // just spins forever. Throwing surfaces it as a retryable error instead.
+    throw new Error(`Failed to download media! Status: ${res.status}`);
+  }
   const blob = await res.blob();
   return blob;
 };

--- a/src/app/utils/notifications.ts
+++ b/src/app/utils/notifications.ts
@@ -5,7 +5,13 @@ export async function markAsRead(mx: MatrixClient, roomId: string, privateReceip
   if (!room) return;
 
   const timeline = room.getLiveTimeline().getEvents();
-  const readEventId = room.getEventReadUpTo(mx.getUserId()!);
+  // `ignoreSynthesized = true`: matrix-js-sdk synthesizes an implicit read receipt
+  // for the sender of every live event, so when our own message is the newest event
+  // the default (non-ignoring) lookup returns that message as "read up to" and
+  // `getLatestValidEvent()` bails out on its first iteration - no receipt is ever
+  // sent and the server's notification count stays stuck. Only server-sent receipts
+  // may decide whether there is anything left to acknowledge.
+  const readEventId = room.getEventReadUpTo(mx.getUserId()!, true);
 
   const getLatestValidEvent = () => {
     for (let i = timeline.length - 1; i >= 0; i -= 1) {

--- a/src/client/initMatrix.ts
+++ b/src/client/initMatrix.ts
@@ -67,6 +67,7 @@ export const logoutClient = async (mx: MatrixClient) => {
 };
 
 export const clearLoginData = async () => {
+  pushSessionToSW();
   const dbs = await window.indexedDB.databases();
 
   dbs.forEach((idbInfo) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,6 +35,16 @@ if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register(swUrl).then(sendSessionToSW);
   navigator.serviceWorker.ready.then(sendSessionToSW);
 
+  // A newly activated (or respawned) worker starts with no session, and taking
+  // control of this page is the moment it begins serving our media requests.
+  navigator.serviceWorker.addEventListener('controllerchange', sendSessionToSW);
+
+  // Cheap safety net: refresh the worker's copy whenever the tab comes back to
+  // the foreground, which is also when media is about to be requested again.
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') sendSessionToSW();
+  });
+
   navigator.serviceWorker.addEventListener('message', (ev) => {
     const { type } = ev.data ?? {};
 

--- a/src/sw-session.ts
+++ b/src/sw-session.ts
@@ -1,10 +1,24 @@
-export function pushSessionToSW(baseUrl?: string, accessToken?: string) {
-  if (!('serviceWorker' in navigator)) return;
-  if (!navigator.serviceWorker.controller) return;
-
-  navigator.serviceWorker.controller.postMessage({
+function postSession(target: ServiceWorker | null, baseUrl?: string, accessToken?: string) {
+  target?.postMessage({
     type: 'setSession',
     accessToken,
     baseUrl,
+  });
+}
+
+export function pushSessionToSW(baseUrl?: string, accessToken?: string) {
+  if (!('serviceWorker' in navigator)) return;
+
+  const { controller } = navigator.serviceWorker;
+  if (controller) {
+    postSession(controller, baseUrl, accessToken);
+    return;
+  }
+
+  // On the first load of a fresh registration this page is not controlled yet,
+  // so there is no controller to talk to. The active worker can still be given
+  // the session - it will need it as soon as it starts serving our media.
+  navigator.serviceWorker.ready.then((registration) => {
+    postSession(registration.active, baseUrl, accessToken);
   });
 }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -16,6 +16,81 @@ const sessions = new Map<string, SessionInfo>();
 const clientToResolve = new Map<string, (value: SessionInfo | undefined) => void>();
 const clientToSessionPromise = new Map<string, Promise<SessionInfo | undefined>>();
 
+/**
+ * The browser terminates an idle service worker after a few seconds and respawns it
+ * for the next fetch with the maps above empty. Asking the page for the session again
+ * can take a very long time (or never be answered) while its main thread is busy, and
+ * serving an authenticated media request without a token is a guaranteed 401. So the
+ * last known session is also kept in this worker's own Cache storage, which survives
+ * the respawn.
+ *
+ * The access token already lives in this origin's localStorage, so a copy in this
+ * origin's cache storage is not a new exposure. It is removed as soon as the page
+ * reports that there is no session anymore (logout).
+ */
+const SESSION_CACHE_NAME = 'cinny-sw-session';
+const SESSION_CACHE_KEY = '/__cinny_sw_session__';
+
+let lastSession: SessionInfo | undefined;
+let persistedSession: Promise<SessionInfo | undefined> | undefined;
+
+function toSessionInfo(data: unknown): SessionInfo | undefined {
+  const { accessToken, baseUrl } = (data ?? {}) as Partial<SessionInfo>;
+  if (typeof accessToken === 'string' && typeof baseUrl === 'string') {
+    return { accessToken, baseUrl };
+  }
+  return undefined;
+}
+
+async function loadPersistedSession(): Promise<SessionInfo | undefined> {
+  try {
+    const cache = await self.caches.open(SESSION_CACHE_NAME);
+    const res = await cache.match(SESSION_CACHE_KEY);
+    if (!res) return undefined;
+    return toSessionInfo(await res.json());
+  } catch {
+    // Cache storage unavailable or the entry is unreadable - act as if empty.
+    return undefined;
+  }
+}
+
+async function persistSession(session: SessionInfo | undefined): Promise<void> {
+  try {
+    const cache = await self.caches.open(SESSION_CACHE_NAME);
+    if (!session) {
+      await cache.delete(SESSION_CACHE_KEY);
+      return;
+    }
+    await cache.put(
+      SESSION_CACHE_KEY,
+      new Response(JSON.stringify(session), {
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+  } catch {
+    // Ignore - the in-memory session still covers this worker's lifetime.
+  }
+}
+
+let persistQueue: Promise<void> = Promise.resolve();
+
+/**
+ * Serialize the writes so the newest session always wins - a login immediately
+ * followed by a logout must not leave the old token behind.
+ */
+function queuePersistSession(session: SessionInfo | undefined): Promise<void> {
+  persistQueue = persistQueue.then(() => persistSession(session));
+  return persistQueue;
+}
+
+function getLastKnownSession(): Promise<SessionInfo | undefined> {
+  if (lastSession) return Promise.resolve(lastSession);
+  if (!persistedSession) {
+    persistedSession = loadPersistedSession();
+  }
+  return persistedSession;
+}
+
 async function cleanupDeadClients() {
   const activeClients = await self.clients.matchAll();
   const activeIds = new Set(activeClients.map((c) => c.id));
@@ -29,13 +104,23 @@ async function cleanupDeadClients() {
   });
 }
 
-function setSession(clientId: string, accessToken: any, baseUrl: any) {
-  if (typeof accessToken === 'string' && typeof baseUrl === 'string') {
-    sessions.set(clientId, { accessToken, baseUrl });
+function setSession(clientId: string, accessToken: unknown, baseUrl: unknown): Promise<void> {
+  const session = toSessionInfo({ accessToken, baseUrl });
+  if (session) {
+    sessions.set(clientId, session);
   } else {
     // Logout or invalid session
     sessions.delete(clientId);
   }
+
+  const unchanged =
+    !!session &&
+    !!lastSession &&
+    lastSession.accessToken === session.accessToken &&
+    lastSession.baseUrl === session.baseUrl;
+
+  lastSession = session;
+  persistedSession = Promise.resolve(session);
 
   const resolveSession = clientToResolve.get(clientId);
   if (resolveSession) {
@@ -43,6 +128,11 @@ function setSession(clientId: string, accessToken: any, baseUrl: any) {
     clientToResolve.delete(clientId);
     clientToSessionPromise.delete(clientId);
   }
+
+  // Pages re-push the same session on every load and on every tab focus; only
+  // write when it actually changed (a removal is always written).
+  if (unchanged) return Promise.resolve();
+  return queuePersistSession(session);
 }
 
 function requestSession(client: Client): Promise<SessionInfo | undefined> {
@@ -62,7 +152,7 @@ function requestSession(client: Client): Promise<SessionInfo | undefined> {
 
 async function requestSessionWithTimeout(
   clientId: string,
-  timeoutMs = 3000
+  timeoutMs = 10000
 ): Promise<SessionInfo | undefined> {
   const client = await self.clients.get(clientId);
   if (!client) return undefined;
@@ -99,7 +189,9 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
   const { type, accessToken, baseUrl } = event.data || {};
 
   if (type === 'setSession') {
-    setSession(client.id, accessToken, baseUrl);
+    // waitUntil so the worker is not terminated before the session is persisted
+    // (or cleared, on logout, where the page reloads right after).
+    event.waitUntil(setSession(client.id, accessToken, baseUrl));
     cleanupDeadClients();
   }
 });
@@ -137,9 +229,8 @@ self.addEventListener('fetch', (event: FetchEvent) => {
   if (method !== 'GET' || !mediaPath(url)) return;
 
   const { clientId } = event;
-  if (!clientId) return;
 
-  const session = sessions.get(clientId);
+  const session = clientId ? sessions.get(clientId) : undefined;
   if (session) {
     if (validMediaRequest(url, session.baseUrl)) {
       event.respondWith(fetch(url, fetchConfig(session.accessToken)));
@@ -148,11 +239,28 @@ self.addEventListener('fetch', (event: FetchEvent) => {
   }
 
   event.respondWith(
-    requestSessionWithTimeout(clientId).then((s) => {
-      if (s && validMediaRequest(url, s.baseUrl)) {
-        return fetch(url, fetchConfig(s.accessToken));
+    (async () => {
+      // The session this worker last saw: from memory, or restored from cache
+      // storage after the worker was terminated and respawned.
+      const knownSession = await getLastKnownSession();
+      if (knownSession) {
+        if (validMediaRequest(url, knownSession.baseUrl)) {
+          return fetch(url, fetchConfig(knownSession.accessToken));
+        }
+        // Some other host's media path - never attach our token to it.
+        return fetch(event.request);
       }
+
+      // Nothing stored at all: ask the page, and wait for it. On a large account
+      // its main thread can be blocked for many seconds, and answering early with
+      // a credential-less request only produces a 401 that looks like a broken file.
+      const pageSession = clientId ? await requestSessionWithTimeout(clientId) : undefined;
+      if (pageSession && validMediaRequest(url, pageSession.baseUrl)) {
+        return fetch(url, fetchConfig(pageSession.accessToken));
+      }
+
+      // Truly no session (e.g. logged out) - let the request go as it is.
       return fetch(event.request);
-    })
+    })()
   );
 });


### PR DESCRIPTION
The idea is to get rid of showing those type of unread rooms and keep only the ones with the number which are a lot more reliable and important.

This is how it looks before:
<img width="868" height="1866" alt="image" src="https://github.com/user-attachments/assets/21c2bddd-7195-44b3-bf5f-d94ce4a9ae58" />

and this is after:
<img width="803" height="1445" alt="image" src="https://github.com/user-attachments/assets/e4efb154-54bf-4696-a3dd-137b873c49b7" />


