### PR TITLE
fix: support audio with ogg filetype

### DIFF
--- a/src/app/utils/mimeTypes.ts
+++ b/src/app/utils/mimeTypes.ts
@@ -31,6 +31,7 @@ export const APPLICATION_MIME_TYPES = [
   'application/javascript',
   'application/xhtml+xml',
   'application/xml',
+  'application/ogg',
 ];
 
 export const TEXT_MIME_TYPE = [
@@ -114,6 +115,10 @@ export const getBlobSafeMimeType = (mimeType: string) => {
   // Required for Chromium browsers
   if (type === 'video/quicktime') {
     return 'video/mp4';
+  }
+  // Fixes missing playback for Ogg audio
+  if (type === 'application/ogg') {
+    return 'audio/ogg';
   }
   return type;
 };


### PR DESCRIPTION
This adds a workaround to support playback for directly uploaded .ogg (`application/ogg`) files. Proper handling would require probing the container for all multimedia formats but WebM replaced all uses of this so Ogg video has become exceedingly rare.

<table>
<tr>
<th>Before</th>
<th>After</th>
<tr>
<td><img width="401" height="97" alt="Screenshot_26-05-04_10-00-34" src="https://github.com/user-attachments/assets/80ccef8b-ae99-4f91-9e36-4a97b7f2f84a" /></td>
<td><img width="402" height="108" alt="Screenshot_26-05-04_10-01-20" src="https://github.com/user-attachments/assets/4ec45ba4-e967-4d3b-ac69-90d1aa61de2f" /></td>
</tr>
</table>
