### PR TITLE
Fix scroll restore for first timeline item

### DIFF
--- a/src/app/hooks/useVirtualPaginator.ts
+++ b/src/app/hooks/useVirtualPaginator.ts
@@ -133,7 +133,7 @@ const getRestoreAnchor = (
 
 const getRestoreScrollData = (scrollTop: number, restoreAnchorData: RestoreAnchorData) => {
   const [anchorItem, anchorElement] = restoreAnchorData;
-  if (!anchorItem || !anchorElement) {
+  if (typeof anchorItem !== 'number' || !anchorElement) {
     return undefined;
   }
   return {


### PR DESCRIPTION
## Summary

Fixes a scroll restoration edge case in `useVirtualPaginator` where timeline item index `0` was treated as missing because the anchor check used a generic falsy test.

When the restore anchor is the first rendered item, `anchorItem` is `0`. The previous condition returned `undefined`, so pagination could skip scroll restoration for that valid anchor.

## Change

- Treat only non-number anchor indexes as missing.
- Preserve `0` as a valid restore anchor.

## Validation

- `npm ci`
- `npx eslint src/app/hooks/useVirtualPaginator.ts`
- `git diff --check`
