### PR TITLE
chore: Update GITHUB_TOKEN to CLA_PAT in prod workflow

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run semantic release
         run: npm run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CLA_PAT }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_AUTHOR_NAME }}


### PR DESCRIPTION
Changed GITHUB_TOKEN secret to CLA_PAT for semantic release due to branch protection.