### PR TITLE
fix: space title and description overflow in lobby

### DIFF
--- a/src/app/components/page/Page.tsx
+++ b/src/app/components/page/Page.tsx
@@ -147,10 +147,10 @@ export function PageHero({
         {icon}
       </Box>
       <Box as="h2" direction="Column" gap="200" alignItems="Center">
-        <Text align="Center" size="H2">
+        <Text align="Center" size="H2" className={css.PageHeroText}>
           {title}
         </Text>
-        <Text align="Center" priority="400">
+        <Text align="Center" priority="400" className={css.PageHeroText}>
           {subTitle}
         </Text>
       </Box>

--- a/src/app/components/page/Page.tsx
+++ b/src/app/components/page/Page.tsx
@@ -147,10 +147,10 @@ export function PageHero({
         {icon}
       </Box>
       <Box as="h2" direction="Column" gap="200" alignItems="Center">
-        <Text align="Center" size="H2" className={css.PageHeroText}>
+        <Text align="Center" size="H2">
           {title}
         </Text>
-        <Text align="Center" priority="400" className={css.PageHeroText}>
+        <Text align="Center" priority="400">
           {subTitle}
         </Text>
       </Box>

--- a/src/app/components/page/style.css.ts
+++ b/src/app/components/page/style.css.ts
@@ -111,12 +111,6 @@ export const PageHeroSection = style([
   },
 ]);
 
-export const PageHeroText = style({
-  minWidth: 0,
-  maxWidth: '100%',
-  overflowWrap: 'anywhere',
-  wordBreak: 'break-word',
-});
 
 export const PageContentCenter = style([
   DefaultReset,

--- a/src/app/components/page/style.css.ts
+++ b/src/app/components/page/style.css.ts
@@ -111,6 +111,13 @@ export const PageHeroSection = style([
   },
 ]);
 
+export const PageHeroText = style({
+  minWidth: 0,
+  maxWidth: '100%',
+  overflowWrap: 'anywhere',
+  wordBreak: 'break-word',
+});
+
 export const PageContentCenter = style([
   DefaultReset,
   {

--- a/src/app/features/lobby/LobbyHero.css.tsx
+++ b/src/app/features/lobby/LobbyHero.css.tsx
@@ -2,6 +2,9 @@ import { style } from '@vanilla-extract/css';
 import { config } from 'folds';
 
 export const LobbyHeroTopic = style({
+  display: '-webkit-box',
+  WebkitLineClamp: 3,
+  WebkitBoxOrient: 'vertical',
   overflow: 'hidden',
   wordBreak: 'break-word',
 

--- a/src/app/features/lobby/LobbyHero.css.tsx
+++ b/src/app/features/lobby/LobbyHero.css.tsx
@@ -2,10 +2,14 @@ import { style } from '@vanilla-extract/css';
 import { config } from 'folds';
 
 export const LobbyHeroTopic = style({
-  display: '-webkit-box',
-  WebkitLineClamp: 3,
-  WebkitBoxOrient: 'vertical',
+  display: 'block',
   overflow: 'hidden',
+  minWidth: 0,
+  width: '100%',
+  whiteSpace: 'normal',
+  overflowWrap: 'anywhere',
+  wordBreak: 'break-word',
+  hyphens: 'auto',
 
   ':hover': {
     cursor: 'pointer',

--- a/src/app/features/lobby/LobbyHero.css.tsx
+++ b/src/app/features/lobby/LobbyHero.css.tsx
@@ -2,14 +2,8 @@ import { style } from '@vanilla-extract/css';
 import { config } from 'folds';
 
 export const LobbyHeroTopic = style({
-  display: 'block',
   overflow: 'hidden',
-  minWidth: 0,
-  width: '100%',
-  whiteSpace: 'normal',
-  overflowWrap: 'anywhere',
   wordBreak: 'break-word',
-  hyphens: 'auto',
 
   ':hover': {
     cursor: 'pointer',


### PR DESCRIPTION

<details>


### Before:

<img width="1101" height="315" alt="image" src="https://github.com/user-attachments/assets/5955a160-1971-40e2-bdf6-75d343e3438b" />


### After:

<img width="807" height="357" alt="Screenshot 2026-05-27 062046" src="https://github.com/user-attachments/assets/fccdb0b6-79e6-4d5f-97ae-680954c7a35e" />


</details>




Closes: #2843
