### PR TITLE
feat: add favourite rooms section

### DIFF
--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -28,6 +28,7 @@ import { nameInitials } from '../../utils/common';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import { useRoomUnread } from '../../state/hooks/unread';
 import { roomToUnreadAtom } from '../../state/room/roomToUnread';
+import { favouriteRoomsAtom } from '../../state/room/favouriteRooms';
 import { getPowersLevelFromMatrixEvent, usePowerLevels } from '../../hooks/usePowerLevels';
 import { copyToClipboard } from '../../utils/dom';
 import { markAsRead } from '../../utils/notifications';
@@ -59,7 +60,7 @@ import { callChatAtom } from '../../state/callEmbed';
 import { useCallPreferencesAtom } from '../../state/hooks/callPreferences';
 import { useAutoDiscoveryInfo } from '../../hooks/useAutoDiscoveryInfo';
 import { livekitSupport } from '../../hooks/useLivekitSupport';
-import { StateEvent } from '../../../types/matrix/room';
+import { RoomTag, StateEvent } from '../../../types/matrix/room';
 import { webRTCSupported } from '../../utils/rtc';
 
 type RoomNavItemMenuProps = {
@@ -79,6 +80,8 @@ const RoomNavItemMenu = forwardRef<HTMLDivElement, RoomNavItemMenuProps>(
     const canInvite = permissions.action('invite', mx.getSafeUserId());
     const openRoomSettings = useOpenRoomSettings();
     const space = useSpaceOptionally();
+    const favouriteRooms = useAtomValue(favouriteRoomsAtom);
+    const favourite = favouriteRooms.has(room.roomId);
 
     const [invitePrompt, setInvitePrompt] = useState(false);
 
@@ -103,6 +106,14 @@ const RoomNavItemMenu = forwardRef<HTMLDivElement, RoomNavItemMenuProps>(
       requestClose();
     };
 
+    const handleToggleFavourite = () => {
+      const promise = favourite
+        ? mx.deleteRoomTag(room.roomId, RoomTag.Favourite)
+        : mx.setRoomTag(room.roomId, RoomTag.Favourite, {});
+      promise.catch(() => undefined);
+      requestClose();
+    };
+
     return (
       <Menu ref={ref} style={{ maxWidth: toRem(160), width: '100vw' }}>
         {invitePrompt && room && (
@@ -115,6 +126,17 @@ const RoomNavItemMenu = forwardRef<HTMLDivElement, RoomNavItemMenuProps>(
           />
         )}
         <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>
+          <MenuItem
+            onClick={handleToggleFavourite}
+            size="300"
+            after={<Icon size="100" src={Icons.Star} filled={favourite} />}
+            radii="300"
+            aria-pressed={favourite}
+          >
+            <Text style={{ flexGrow: 1 }} as="span" size="T300" truncate>
+              {favourite ? 'Remove from Favourites' : 'Add to Favourites'}
+            </Text>
+          </MenuItem>
           <MenuItem
             onClick={handleMarkAsRead}
             size="300"

--- a/src/app/pages/client/direct/Direct.tsx
+++ b/src/app/pages/client/direct/Direct.tsx
@@ -36,6 +36,7 @@ import { VirtualTile } from '../../../components/virtualizer';
 import { RoomNavCategoryButton, RoomNavItem } from '../../../features/room-nav';
 import { makeNavCategoryId } from '../../../state/closedNavCategories';
 import { roomToUnreadAtom } from '../../../state/room/roomToUnread';
+import { favouriteRoomsAtom } from '../../../state/room/favouriteRooms';
 import { useCategoryHandler } from '../../../hooks/useCategoryHandler';
 import { useNavToActivePathMapper } from '../../../hooks/useNavToActivePathMapper';
 import { useDirectRooms } from './useDirectRooms';
@@ -168,11 +169,17 @@ function DirectEmpty() {
 }
 
 const DEFAULT_CATEGORY_ID = makeNavCategoryId('direct', 'direct');
+const FAVOURITE_CATEGORY_ID = makeNavCategoryId('direct', 'favourite');
+
+type DirectVirtualItem =
+  | { type: 'category'; id: string; name: string; closed: boolean }
+  | { type: 'room'; roomId: string };
 export function Direct() {
   const mx = useMatrixClient();
   useNavToActivePathMapper('direct');
   const scrollRef = useRef<HTMLDivElement>(null);
   const directs = useDirectRooms();
+  const favouriteRooms = useAtomValue(favouriteRoomsAtom);
   const notificationPreferences = useRoomsNotificationPreferencesContext();
   const roomToUnread = useAtomValue(roomToUnreadAtom);
   const navigate = useNavigate();
@@ -183,16 +190,47 @@ export function Direct() {
   const noRoomToDisplay = directs.length === 0;
   const [closedCategories, setClosedCategories] = useAtom(useClosedNavCategoriesAtom());
 
-  const sortedDirects = useMemo(() => {
-    const items = Array.from(directs).sort(factoryRoomIdByActivity(mx));
-    if (closedCategories.has(DEFAULT_CATEGORY_ID)) {
-      return items.filter((rId) => roomToUnread.has(rId) || rId === selectedRoomId);
+  const [favouriteRoomIds, otherRoomIds] = useMemo(() => {
+    const favs: string[] = [];
+    const others: string[] = [];
+    directs.forEach((roomId) => {
+      if (favouriteRooms.has(roomId)) favs.push(roomId);
+      else others.push(roomId);
+    });
+    return [favs, others];
+  }, [directs, favouriteRooms]);
+
+  const virtualItems = useMemo(() => {
+    const makeDirectList = (roomIds: string[], closed: boolean): string[] => {
+      const sorted = Array.from(roomIds).sort(factoryRoomIdByActivity(mx));
+      return closed
+        ? sorted.filter((rId) => roomToUnread.has(rId) || rId === selectedRoomId)
+        : sorted;
+    };
+
+    const items: DirectVirtualItem[] = [];
+
+    if (favouriteRoomIds.length > 0) {
+      const closed = closedCategories.has(FAVOURITE_CATEGORY_ID);
+      items.push({ type: 'category', id: FAVOURITE_CATEGORY_ID, name: 'Favourites', closed });
+      makeDirectList(favouriteRoomIds, closed).forEach((roomId) =>
+        items.push({ type: 'room', roomId })
+      );
     }
+
+    if (otherRoomIds.length > 0 || favouriteRoomIds.length === 0) {
+      const closed = closedCategories.has(DEFAULT_CATEGORY_ID);
+      items.push({ type: 'category', id: DEFAULT_CATEGORY_ID, name: 'Chats', closed });
+      makeDirectList(otherRoomIds, closed).forEach((roomId) =>
+        items.push({ type: 'room', roomId })
+      );
+    }
+
     return items;
-  }, [mx, directs, closedCategories, roomToUnread, selectedRoomId]);
+  }, [mx, favouriteRoomIds, otherRoomIds, closedCategories, roomToUnread, selectedRoomId]);
 
   const virtualizer = useVirtualizer({
-    count: sortedDirects.length,
+    count: virtualItems.length,
     getScrollElement: () => scrollRef.current,
     estimateSize: () => 38,
     overscan: 10,
@@ -228,49 +266,64 @@ export function Direct() {
                 </NavButton>
               </NavItem>
             </NavCategory>
-            <NavCategory>
-              <NavCategoryHeader>
-                <RoomNavCategoryButton
-                  closed={closedCategories.has(DEFAULT_CATEGORY_ID)}
-                  data-category-id={DEFAULT_CATEGORY_ID}
-                  onClick={handleCategoryClick}
-                >
-                  Chats
-                </RoomNavCategoryButton>
-              </NavCategoryHeader>
-              <div
-                style={{
-                  position: 'relative',
-                  height: virtualizer.getTotalSize(),
-                }}
-              >
-                {virtualizer.getVirtualItems().map((vItem) => {
-                  const roomId = sortedDirects[vItem.index];
-                  const room = mx.getRoom(roomId);
-                  if (!room) return null;
-                  const selected = selectedRoomId === roomId;
+            <NavCategory
+              style={{
+                height: virtualizer.getTotalSize(),
+                position: 'relative',
+              }}
+            >
+              {virtualizer.getVirtualItems().map((vItem) => {
+                const item = virtualItems[vItem.index];
+                if (!item) return null;
 
+                if (item.type === 'category') {
                   return (
                     <VirtualTile
                       virtualItem={vItem}
                       key={vItem.index}
                       ref={virtualizer.measureElement}
                     >
-                      <RoomNavItem
-                        room={room}
-                        selected={selected}
-                        showAvatar
-                        direct
-                        linkPath={getDirectRoomPath(getCanonicalAliasOrRoomId(mx, roomId))}
-                        notificationMode={getRoomNotificationMode(
-                          notificationPreferences,
-                          room.roomId
-                        )}
-                      />
+                      <div
+                        style={{ paddingTop: vItem.index === 0 ? undefined : config.space.S400 }}
+                      >
+                        <NavCategoryHeader>
+                          <RoomNavCategoryButton
+                            closed={item.closed}
+                            data-category-id={item.id}
+                            onClick={handleCategoryClick}
+                          >
+                            {item.name}
+                          </RoomNavCategoryButton>
+                        </NavCategoryHeader>
+                      </div>
                     </VirtualTile>
                   );
-                })}
-              </div>
+                }
+
+                const room = mx.getRoom(item.roomId);
+                if (!room) return null;
+                const selected = selectedRoomId === item.roomId;
+
+                return (
+                  <VirtualTile
+                    virtualItem={vItem}
+                    key={vItem.index}
+                    ref={virtualizer.measureElement}
+                  >
+                    <RoomNavItem
+                      room={room}
+                      selected={selected}
+                      showAvatar
+                      direct
+                      linkPath={getDirectRoomPath(getCanonicalAliasOrRoomId(mx, item.roomId))}
+                      notificationMode={getRoomNotificationMode(
+                        notificationPreferences,
+                        room.roomId
+                      )}
+                    />
+                  </VirtualTile>
+                );
+              })}
             </NavCategory>
           </Box>
         </PageNavContent>

--- a/src/app/pages/client/home/Home.tsx
+++ b/src/app/pages/client/home/Home.tsx
@@ -49,6 +49,9 @@ import { VirtualTile } from '../../../components/virtualizer';
 import { RoomNavCategoryButton, RoomNavItem } from '../../../features/room-nav';
 import { makeNavCategoryId } from '../../../state/closedNavCategories';
 import { roomToUnreadAtom } from '../../../state/room/roomToUnread';
+import { favouriteRoomsAtom } from '../../../state/room/favouriteRooms';
+import { allRoomsAtom } from '../../../state/room-list/roomList';
+import { mDirectAtom } from '../../../state/mDirectList';
 import { useCategoryHandler } from '../../../hooks/useCategoryHandler';
 import { useNavToActivePathMapper } from '../../../hooks/useNavToActivePathMapper';
 import { PageNav, PageNavHeader, PageNavContent } from '../../../components/page';
@@ -194,11 +197,19 @@ function HomeEmpty() {
 }
 
 const DEFAULT_CATEGORY_ID = makeNavCategoryId('home', 'room');
+const FAVOURITE_CATEGORY_ID = makeNavCategoryId('home', 'favourite');
+
+type HomeVirtualItem =
+  | { type: 'category'; id: string; name: string; closed: boolean }
+  | { type: 'room'; roomId: string };
 export function Home() {
   const mx = useMatrixClient();
   useNavToActivePathMapper('home');
   const scrollRef = useRef<HTMLDivElement>(null);
   const rooms = useHomeRooms();
+  const favouriteRooms = useAtomValue(favouriteRoomsAtom);
+  const allRooms = useAtomValue(allRoomsAtom);
+  const mDirects = useAtomValue(mDirectAtom);
   const notificationPreferences = useRoomsNotificationPreferencesContext();
   const roomToUnread = useAtomValue(roomToUnreadAtom);
   const navigate = useNavigate();
@@ -206,23 +217,56 @@ export function Home() {
   const selectedRoomId = useSelectedRoom();
   const createRoomSelected = useHomeCreateSelected();
   const searchSelected = useHomeSearchSelected();
-  const noRoomToDisplay = rooms.length === 0;
   const [closedCategories, setClosedCategories] = useAtom(useClosedNavCategoriesAtom());
 
-  const sortedRooms = useMemo(() => {
-    const items = Array.from(rooms).sort(
-      closedCategories.has(DEFAULT_CATEGORY_ID)
-        ? factoryRoomIdByActivity(mx)
-        : factoryRoomIdByAtoZ(mx)
-    );
-    if (closedCategories.has(DEFAULT_CATEGORY_ID)) {
-      return items.filter((rId) => roomToUnread.has(rId) || rId === selectedRoomId);
+  const favouriteRoomIds = useMemo(
+    () =>
+      allRooms.filter((roomId) => {
+        if (!favouriteRooms.has(roomId) || mDirects.has(roomId)) return false;
+        const room = mx.getRoom(roomId);
+        return !!room && !room.isSpaceRoom();
+      }),
+    [mx, allRooms, favouriteRooms, mDirects]
+  );
+
+  const otherRoomIds = useMemo(
+    () => rooms.filter((roomId) => !favouriteRooms.has(roomId)),
+    [rooms, favouriteRooms]
+  );
+
+  const noRoomToDisplay = otherRoomIds.length === 0 && favouriteRoomIds.length === 0;
+
+  const virtualItems = useMemo(() => {
+    const makeRoomList = (roomIds: string[], closed: boolean): string[] => {
+      const sorted = Array.from(roomIds).sort(
+        closed ? factoryRoomIdByActivity(mx) : factoryRoomIdByAtoZ(mx)
+      );
+      return closed
+        ? sorted.filter((rId) => roomToUnread.has(rId) || rId === selectedRoomId)
+        : sorted;
+    };
+
+    const items: HomeVirtualItem[] = [];
+
+    if (favouriteRoomIds.length > 0) {
+      const closed = closedCategories.has(FAVOURITE_CATEGORY_ID);
+      items.push({ type: 'category', id: FAVOURITE_CATEGORY_ID, name: 'Favourites', closed });
+      makeRoomList(favouriteRoomIds, closed).forEach((roomId) =>
+        items.push({ type: 'room', roomId })
+      );
     }
+
+    if (otherRoomIds.length > 0 || favouriteRoomIds.length === 0) {
+      const closed = closedCategories.has(DEFAULT_CATEGORY_ID);
+      items.push({ type: 'category', id: DEFAULT_CATEGORY_ID, name: 'Rooms', closed });
+      makeRoomList(otherRoomIds, closed).forEach((roomId) => items.push({ type: 'room', roomId }));
+    }
+
     return items;
-  }, [mx, rooms, closedCategories, roomToUnread, selectedRoomId]);
+  }, [mx, favouriteRoomIds, otherRoomIds, closedCategories, roomToUnread, selectedRoomId]);
 
   const virtualizer = useVirtualizer({
-    count: sortedRooms.length,
+    count: virtualItems.length,
     getScrollElement: () => scrollRef.current,
     estimateSize: () => 38,
     overscan: 10,
@@ -312,47 +356,62 @@ export function Home() {
                 </NavLink>
               </NavItem>
             </NavCategory>
-            <NavCategory>
-              <NavCategoryHeader>
-                <RoomNavCategoryButton
-                  closed={closedCategories.has(DEFAULT_CATEGORY_ID)}
-                  data-category-id={DEFAULT_CATEGORY_ID}
-                  onClick={handleCategoryClick}
-                >
-                  Rooms
-                </RoomNavCategoryButton>
-              </NavCategoryHeader>
-              <div
-                style={{
-                  position: 'relative',
-                  height: virtualizer.getTotalSize(),
-                }}
-              >
-                {virtualizer.getVirtualItems().map((vItem) => {
-                  const roomId = sortedRooms[vItem.index];
-                  const room = mx.getRoom(roomId);
-                  if (!room) return null;
-                  const selected = selectedRoomId === roomId;
+            <NavCategory
+              style={{
+                height: virtualizer.getTotalSize(),
+                position: 'relative',
+              }}
+            >
+              {virtualizer.getVirtualItems().map((vItem) => {
+                const item = virtualItems[vItem.index];
+                if (!item) return null;
 
+                if (item.type === 'category') {
                   return (
                     <VirtualTile
                       virtualItem={vItem}
                       key={vItem.index}
                       ref={virtualizer.measureElement}
                     >
-                      <RoomNavItem
-                        room={room}
-                        selected={selected}
-                        linkPath={getHomeRoomPath(getCanonicalAliasOrRoomId(mx, roomId))}
-                        notificationMode={getRoomNotificationMode(
-                          notificationPreferences,
-                          room.roomId
-                        )}
-                      />
+                      <div
+                        style={{ paddingTop: vItem.index === 0 ? undefined : config.space.S400 }}
+                      >
+                        <NavCategoryHeader>
+                          <RoomNavCategoryButton
+                            closed={item.closed}
+                            data-category-id={item.id}
+                            onClick={handleCategoryClick}
+                          >
+                            {item.name}
+                          </RoomNavCategoryButton>
+                        </NavCategoryHeader>
+                      </div>
                     </VirtualTile>
                   );
-                })}
-              </div>
+                }
+
+                const room = mx.getRoom(item.roomId);
+                if (!room) return null;
+                const selected = selectedRoomId === item.roomId;
+
+                return (
+                  <VirtualTile
+                    virtualItem={vItem}
+                    key={vItem.index}
+                    ref={virtualizer.measureElement}
+                  >
+                    <RoomNavItem
+                      room={room}
+                      selected={selected}
+                      linkPath={getHomeRoomPath(getCanonicalAliasOrRoomId(mx, item.roomId))}
+                      notificationMode={getRoomNotificationMode(
+                        notificationPreferences,
+                        room.roomId
+                      )}
+                    />
+                  </VirtualTile>
+                );
+              })}
             </NavCategory>
           </Box>
         </PageNavContent>

--- a/src/app/pages/client/home/RoomProvider.tsx
+++ b/src/app/pages/client/home/RoomProvider.tsx
@@ -1,22 +1,25 @@
 import React, { ReactNode } from 'react';
 import { useParams } from 'react-router-dom';
+import { useAtomValue } from 'jotai';
 import { useSelectedRoom } from '../../../hooks/router/useSelectedRoom';
 import { IsDirectRoomProvider, RoomProvider } from '../../../hooks/useRoom';
 import { useMatrixClient } from '../../../hooks/useMatrixClient';
 import { JoinBeforeNavigate } from '../../../features/join-before-navigate';
 import { useHomeRooms } from './useHomeRooms';
 import { useSearchParamsViaServers } from '../../../hooks/router/useSearchParamsViaServers';
+import { favouriteRoomsAtom } from '../../../state/room/favouriteRooms';
 
 export function HomeRouteRoomProvider({ children }: { children: ReactNode }) {
   const mx = useMatrixClient();
   const rooms = useHomeRooms();
+  const favouriteRooms = useAtomValue(favouriteRoomsAtom);
 
   const { roomIdOrAlias, eventId } = useParams();
   const viaServers = useSearchParamsViaServers();
   const roomId = useSelectedRoom();
   const room = mx.getRoom(roomId);
 
-  if (!room || !rooms.includes(room.roomId)) {
+  if (!room || (!rooms.includes(room.roomId) && !favouriteRooms.has(room.roomId))) {
     return (
       <JoinBeforeNavigate
         roomIdOrAlias={roomIdOrAlias!}

--- a/src/app/state/hooks/useBindAtoms.ts
+++ b/src/app/state/hooks/useBindAtoms.ts
@@ -3,6 +3,7 @@ import { allInvitesAtom, useBindAllInvitesAtom } from '../room-list/inviteList';
 import { allRoomsAtom, useBindAllRoomsAtom } from '../room-list/roomList';
 import { mDirectAtom, useBindMDirectAtom } from '../mDirectList';
 import { roomToUnreadAtom, useBindRoomToUnreadAtom } from '../room/roomToUnread';
+import { favouriteRoomsAtom, useBindFavouriteRoomsAtom } from '../room/favouriteRooms';
 import { roomToParentsAtom, useBindRoomToParentsAtom } from '../room/roomToParents';
 import { roomIdToTypingMembersAtom, useBindRoomIdToTypingMembersAtom } from '../typingMembers';
 
@@ -12,6 +13,7 @@ export const useBindAtoms = (mx: MatrixClient) => {
   useBindAllRoomsAtom(mx, allRoomsAtom);
   useBindRoomToParentsAtom(mx, roomToParentsAtom);
   useBindRoomToUnreadAtom(mx, roomToUnreadAtom);
+  useBindFavouriteRoomsAtom(mx, favouriteRoomsAtom);
 
   useBindRoomIdToTypingMembersAtom(mx, roomIdToTypingMembersAtom);
 };

--- a/src/app/state/room/favouriteRooms.ts
+++ b/src/app/state/room/favouriteRooms.ts
@@ -1,0 +1,97 @@
+import { atom, useSetAtom } from 'jotai';
+import { MatrixClient, MatrixEvent, Room, RoomEvent, SyncState } from 'matrix-js-sdk';
+import { useCallback, useEffect } from 'react';
+import { Membership, RoomTag } from '../../../types/matrix/room';
+import { useSyncState } from '../../hooks/useSyncState';
+
+export type FavouriteRoomsAction =
+  | { type: 'RESET'; rooms: Set<string> }
+  | { type: 'PUT'; roomId: string }
+  | { type: 'DELETE'; roomId: string };
+
+export const isRoomFavourite = (room: Room): boolean => room.tags[RoomTag.Favourite] !== undefined;
+
+const getFavouriteRooms = (mx: MatrixClient): Set<string> => {
+  const favourites = new Set<string>();
+  mx.getRooms().forEach((room) => {
+    if (isRoomFavourite(room)) favourites.add(room.roomId);
+  });
+  return favourites;
+};
+
+const baseFavouriteRoomsAtom = atom(new Set<string>());
+export const favouriteRoomsAtom = atom<Set<string>, [FavouriteRoomsAction], undefined>(
+  (get) => get(baseFavouriteRoomsAtom),
+  (get, set, action) => {
+    if (action.type === 'RESET') {
+      set(baseFavouriteRoomsAtom, action.rooms);
+      return;
+    }
+    const current = get(baseFavouriteRoomsAtom);
+    if (action.type === 'PUT') {
+      if (current.has(action.roomId)) return;
+      const next = new Set(current);
+      next.add(action.roomId);
+      set(baseFavouriteRoomsAtom, next);
+      return;
+    }
+    if (action.type === 'DELETE') {
+      if (!current.has(action.roomId)) return;
+      const next = new Set(current);
+      next.delete(action.roomId);
+      set(baseFavouriteRoomsAtom, next);
+    }
+  }
+);
+
+export const useBindFavouriteRoomsAtom = (
+  mx: MatrixClient,
+  favouriteRooms: typeof favouriteRoomsAtom
+) => {
+  const setFavouriteRooms = useSetAtom(favouriteRooms);
+
+  useEffect(() => {
+    setFavouriteRooms({ type: 'RESET', rooms: getFavouriteRooms(mx) });
+  }, [mx, setFavouriteRooms]);
+
+  useSyncState(
+    mx,
+    useCallback(
+      (state, prevState) => {
+        if (
+          (state === SyncState.Prepared && prevState === null) ||
+          (state === SyncState.Syncing && prevState !== SyncState.Syncing)
+        ) {
+          setFavouriteRooms({ type: 'RESET', rooms: getFavouriteRooms(mx) });
+        }
+      },
+      [mx, setFavouriteRooms]
+    )
+  );
+
+  useEffect(() => {
+    const handleTags = (_event: MatrixEvent, room: Room) => {
+      setFavouriteRooms(
+        isRoomFavourite(room)
+          ? { type: 'PUT', roomId: room.roomId }
+          : { type: 'DELETE', roomId: room.roomId }
+      );
+    };
+    mx.on(RoomEvent.Tags, handleTags);
+    return () => {
+      mx.removeListener(RoomEvent.Tags, handleTags);
+    };
+  }, [mx, setFavouriteRooms]);
+
+  useEffect(() => {
+    const handleMembershipChange = (room: Room, membership: string) => {
+      if (membership !== Membership.Join) {
+        setFavouriteRooms({ type: 'DELETE', roomId: room.roomId });
+      }
+    };
+    mx.on(RoomEvent.MyMembership, handleMembershipChange);
+    return () => {
+      mx.removeListener(RoomEvent.MyMembership, handleMembershipChange);
+    };
+  }, [mx, setFavouriteRooms]);
+};

--- a/src/types/matrix/room.ts
+++ b/src/types/matrix/room.ts
@@ -42,6 +42,11 @@ export enum StateEvent {
   PowerLevelTags = 'in.cinny.room.power_level_tags',
 }
 
+export enum RoomTag {
+  Favourite = 'm.favourite',
+  LowPriority = 'm.lowpriority',
+}
+
 export enum MessageEvent {
   RoomMessage = 'm.room.message',
   RoomMessageEncrypted = 'm.room.encrypted',


### PR DESCRIPTION
Add a collapsible "Favourites" section to the Home and Direct room lists, backed by the standard `m.favourite` room tag. Favourites sync with the homeserver and interoperate with other Matrix clients such as Element and FluffyChat.

- Toggle favourite from the room context menu (sets/deletes m.favourite)
- favouriteRoomsAtom tracks tagged rooms reactively via RoomEvent.Tags
- Home favourites include space-nested rooms; Direct lists favourite DMs

Implements #44