### PR TITLE
fix: deliver session to service worker on first load (authenticated media)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,6 +35,8 @@ if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register(swUrl).then(sendSessionToSW);
   navigator.serviceWorker.ready.then(sendSessionToSW);
 
+  navigator.serviceWorker.addEventListener('controllerchange', sendSessionToSW);
+
   navigator.serviceWorker.addEventListener('message', (ev) => {
     const { type } = ev.data ?? {};
 

--- a/src/sw-session.ts
+++ b/src/sw-session.ts
@@ -1,10 +1,13 @@
 export function pushSessionToSW(baseUrl?: string, accessToken?: string) {
   if (!('serviceWorker' in navigator)) return;
-  if (!navigator.serviceWorker.controller) return;
-
-  navigator.serviceWorker.controller.postMessage({
-    type: 'setSession',
-    accessToken,
-    baseUrl,
-  });
+  const msg = { type: 'setSession', accessToken, baseUrl };
+  // Prefer the controller (controlled page); on first load the controller is
+  // null until the SW claims the page, so fall back to the active worker so
+  // the session reaches the SW before media fetches need it (fixes first-load
+  // 401 / broken images under authenticated media).
+  if (navigator.serviceWorker.controller) {
+    navigator.serviceWorker.controller.postMessage(msg);
+  } else {
+    navigator.serviceWorker.ready.then((reg) => reg.active?.postMessage(msg)).catch(() => {});
+  }
 }


### PR DESCRIPTION
### Problem
With authenticated media enabled (MSC3916; mandatory on Synapse ≥ 1.131), images/media fail with `401 M_MISSING_TOKEN` on a **fresh** load (first visit, hard refresh, incognito) and only work after a second reload.

`pushSessionToSW` posts the access token to the media service worker only when `navigator.serviceWorker.controller` is set. On first load the controller is `null` until the SW claims the page, so the token never reaches the SW before the first media fetches go out → 401 → broken images.

Closes #2990.

### Fix
- `src/sw-session.ts`: when `controller` is null, fall back to `navigator.serviceWorker.ready → registration.active` so the session reaches the SW on first load.
- `src/index.tsx`: also re-push the session on `controllerchange`, once the SW takes control.

Two tiny changes, using existing patterns; no behavior change once the SW is already controlling the page.

### Testing
Verified on a Synapse 1.153 deployment with authenticated media enforced: before, first-load media 401'd until reload; after, media loads on first load (incognito + unregistered-SW tested). `navigator.serviceWorker.controller` is null on that first load, which is the window this fixes.