### PR TITLE
fix: update device management endpoint

### DIFF
--- a/src/app/hooks/useAccountManagement.ts
+++ b/src/app/hooks/useAccountManagement.ts
@@ -4,9 +4,9 @@ export const useAccountManagementActions = () => {
   const actions = useMemo(
     () => ({
       profile: 'org.matrix.profile',
-      sessionsList: 'org.matrix.sessions_list',
-      sessionView: 'org.matrix.session_view',
-      sessionEnd: 'org.matrix.session_end',
+      sessionsList: 'org.matrix.devices_list',
+      sessionView: 'org.matrix.device_view',
+      sessionEnd: 'org.matrix.device_delete',
       accountDeactivate: 'org.matrix.account_deactivate',
       crossSigningReset: 'org.matrix.cross_signing_reset',
     }),


### PR DESCRIPTION
When we added the endpoints were session but they got updated when the MSC is merged into spec. Ref: https://github.com/matrix-org/matrix-spec-proposals/pull/4191#discussion_r2376900233

Synapse redirect old endpoints as well but new implementation like c10y only implemented new endpoints, so we can safely remove them.