### PR TITLE
fix: emoji autocompletion overwriting preceding element

### DIFF
--- a/src/app/components/editor/utils.ts
+++ b/src/app/components/editor/utils.ts
@@ -247,7 +247,7 @@ export const getPrevWorldRange = (editor: Editor): BaseRange | undefined => {
   const [cursorPoint] = Range.edges(selection);
   const worldStartPoint = getPointUntilChar(editor, cursorPoint, {
     reverse: true,
-    match: (char) => char === ' ',
+    match: (char) => char === ' ' || char === '',
   });
   return worldStartPoint && Editor.range(editor, worldStartPoint, cursorPoint);
 };

--- a/src/app/components/editor/utils.ts
+++ b/src/app/components/editor/utils.ts
@@ -241,15 +241,15 @@ export const getPointUntilChar = (
   return targetPoint;
 };
 
-export const getPrevWorldRange = (editor: Editor): BaseRange | undefined => {
+export const getPrevWordRange = (editor: Editor): BaseRange | undefined => {
   const { selection } = editor;
   if (!selection || !Range.isCollapsed(selection)) return undefined;
   const [cursorPoint] = Range.edges(selection);
-  const worldStartPoint = getPointUntilChar(editor, cursorPoint, {
+  const wordStartPoint = getPointUntilChar(editor, cursorPoint, {
     reverse: true,
     match: (char) => char === ' ' || char === '',
   });
-  return worldStartPoint && Editor.range(editor, worldStartPoint, cursorPoint);
+  return wordStartPoint && Editor.range(editor, wordStartPoint, cursorPoint);
 };
 
 export const isEmptyEditor = (editor: Editor): boolean => {

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -39,7 +39,7 @@ import {
   AutocompletePrefix,
   AutocompleteQuery,
   getAutocompleteQuery,
-  getPrevWorldRange,
+  getPrevWordRange,
   resetEditor,
   RoomMentionAutocomplete,
   UserMentionAutocomplete,
@@ -411,7 +411,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
           sendTypingStatus(!isEmptyEditor(editor));
         }
 
-        const prevWordRange = getPrevWorldRange(editor);
+        const prevWordRange = getPrevWordRange(editor);
         const query = prevWordRange
           ? getAutocompleteQuery<AutocompletePrefix>(editor, prevWordRange, AUTOCOMPLETE_PREFIXES)
           : undefined;

--- a/src/app/features/room/message/MessageEditor.tsx
+++ b/src/app/features/room/message/MessageEditor.tsx
@@ -35,7 +35,7 @@ import {
   createEmoticonElement,
   customHtmlEqualsPlainText,
   getAutocompleteQuery,
-  getPrevWorldRange,
+  getPrevWordRange,
   htmlToEditorInput,
   moveCursor,
   plainToEditorInput,
@@ -187,7 +187,7 @@ export const MessageEditor = as<'div', MessageEditorProps>(
           return;
         }
 
-        const prevWordRange = getPrevWorldRange(editor);
+        const prevWordRange = getPrevWordRange(editor);
         const query = prevWordRange
           ? getAutocompleteQuery<AutocompletePrefix>(editor, prevWordRange, AUTOCOMPLETE_PREFIXES)
           : undefined;


### PR DESCRIPTION
Fixes #3063. Also fixes a couple typos of "word" as "world".

The function `getPrevWordRange` (formerly known as `getPrevWorldRange`) would include the empty text children of elements like emojis, causing such elements to be deleted if they immediately preceded autocompletions.

It now stops if it detects a `char === ''` which indicates that it has encountered an empty text node. This allows emojis to be created next to each other without error. 