### PR TITLE
feat: Discord-style thread side-panel (thread drawer, summaries, real unreads, media fixes)

### DIFF
--- a/README.fork.md
+++ b/README.fork.md
@@ -1,0 +1,111 @@
+# Cinny Threads Fork
+
+A fork of [Cinny](https://github.com/cinnyapp/cinny) v4.12.6 that adds a
+**Discord-style thread side-panel** — the feature Cinny doesn't have.
+
+Cinny is a beautiful, Discord-style Matrix client, but it renders threads inline in
+the room timeline with no dedicated thread panel. This fork adds a proper thread
+drawer docked to the right of the room view, modeled on Cinny's existing member
+drawer, plus Element-style thread summaries on root messages in the main timeline.
+
+> **Upstream status:** Cinny is [not accepting pull requests](https://github.com/cinnyapp/cinny/issues/257)
+> while they replace the matrix-js-sdk with their own SDK. This fork is pinned to
+> v4.12.6 and maintained independently until upstream reopens. A PR has been opened
+> upstream for visibility — see the link in the PR section below.
+
+## Features
+
+### Thread side-panel drawer (`ThreadsDrawer`)
+- **Thread list** — every thread in the room, with root message preview, reply count,
+  and a white unread-count pill. One-line rows, no sender prefix.
+- **Thread detail view** — renders the full thread conversation inside the drawer,
+  reusing Cinny's existing message renderers (so it looks identical to the main
+  timeline). Supports `m.room.message`, `m.room.encrypted` (with decrypt/retry
+  states), and `m.sticker` events, plus edited messages (`m.new_content`).
+- **Thread reply composer** — reply directly from the drawer with `@mention`
+  autocomplete pills, emoji/sticker pickers, and auto-expand. Sends
+  `m.relates_to { rel_type: 'm.thread', event_id }` relations correctly.
+- **Resizable** — drag the left edge to resize (min 320px, max 640px, default 400px);
+  width persists to `localStorage`.
+- **Overflow menu** — vertical-dots menu (mirroring Cinny's room menu) with
+  **Mark as Read** (sends a threaded read receipt), **View in Thread** (focuses the
+  root message in the main timeline), and **Copy Link**.
+- **Auto-mark-read** — opening a thread detail sends a threaded read receipt, clearing
+  the unread pill and the main-timeline summary indicator.
+- **Live updates** — new threads and new replies appear live without a reload;
+  the detail view auto-scrolls to new replies.
+- **Desktop only** — collapses on mobile, same as the member drawer. Toggled via
+  a threads `IconButton` in the room header (mutually exclusive with the member drawer).
+
+### Element-style thread summaries (`ThreadSummary`)
+- Thread root messages in the main timeline show a clickable summary row beneath them
+  (thread icon + last-reply preview + reply count) when they have replies.
+- When the thread has unread replies, the icon swaps to an accent thread-unread icon
+  and a white unread-count pill appears.
+- Clicking the summary opens the thread in the drawer.
+
+### Real unread message counts in channel badges
+- The left-side channel list badge now shows the **actual number of unread messages**
+  (walking the live timeline from the read receipt to the end), not the SDK push-rule
+  notification count which returns 0 for "Mentions & Keywords only" rooms. Matches
+  Element behavior.
+
+### Adaptive authenticated media (`useMediaAuthentication`)
+- Cinny v4.12.6 generates authenticated v1 media URLs when the server advertises
+  spec v1.11, but the service worker that injects the Bearer token only works in
+  secure contexts (HTTPS / localhost). On plain HTTP LAN IPs the SW can't register,
+  so media 401s and avatars never load.
+- This fork gates `useMediaAuthentication` on `window.isSecureContext` so
+  authenticated v1 URLs are only generated when the SW can actually register, falling
+  back to unauthenticated v3 media URLs over plain HTTP. Works for both
+  `https://chat.example.com` and `http://10.0.0.5:8083` access patterns.
+
+### Build fix: crypto WASM glue
+- The matrix-js-sdk crypto WASM chunk references `matrix_sdk_crypto_wasm_bg.js` at
+  module load time, but `@rollup/plugin-wasm` only emits the `.wasm` file. This fork
+  adds the glue JS to `viteStaticCopy` targets so it lands in `dist/assets/` and the
+  crypto SDK loads instead of crashing with "Failed to fetch dynamically imported
+  module" on routes that lazy-load it (e.g. post-SSO).
+
+## Settings
+
+A new **Threads** toggle appears in *Settings → General*:
+"Show a threads side panel for the open room (desktop)". Off by default.
+
+## Building
+
+```bash
+npm ci
+npm run build
+# dist/ contains the built SPA
+```
+
+Requires Node 18+ (tested on Node 26). The build is pure Vite (esbuild strips types;
+no `tsc` gate). Deploy `dist/` to any static host behind a reverse proxy that routes
+`/_matrix/*` to your Synapse.
+
+## Branch structure
+
+| Branch | Description |
+|--------|-------------|
+| `baseline-v4.12.6` | Clean upstream v4.12.6 (commit `33f4ba3`) — the pin point |
+| `feature/threads-panel` | All thread-panel + fix commits on top of the baseline |
+
+Rebasing to a future Cinny release: create a fresh `baseline-vX.Y` from upstream,
+then `git rebase --onto baseline-vX.Y baseline-v4.12.6 feature/threads-panel`.
+
+## Commits
+
+25 commits on top of v4.12.6. See `docs/thread-panel-rfc.md` for the original
+implementation RFC and design notes.
+
+## Acknowledgements
+
+All credit for the Cinny client and its design goes to the
+[cinnyapp/cinny](https://github.com/cinnyapp/cinny) team. This fork exists only because
+upstream is temporarily closed to contributions during their SDK rewrite, and a
+thread panel was needed in the meantime.
+
+## License
+
+[AGPL-3.0](./LICENSE) — same as upstream Cinny.

--- a/docs/thread-panel-rfc.md
+++ b/docs/thread-panel-rfc.md
@@ -1,0 +1,149 @@
+# Cinny Thread Side-Panel — Implementation RFC
+
+**Fork:** `cinny-fork` @ `baseline-v4.12.6` (commit `33f4ba3`, matches the build served at `10.1.0.220:8083`)
+**SDK:** matrix-js-sdk `41.7.0`
+**Status:** Plan (pending implementation approval)
+
+## 1. Goal
+
+Add a Discord-style side-panel for threads to Cinny, exposed as a **user setting**
+(`Threads` toggle in General settings). When enabled on desktop, the room view gains a
+threads drawer (docked right, mirroring the existing member drawer) that:
+
+- lists the room's active/recent threads (root message snippet + last-activity + unread),
+- opens a selected thread into a read view inside the panel (reusing Cinny's existing message renderers),
+- is mutually exclusive with the member drawer (both live in the same right-column slot),
+- collapses on mobile (same `ScreenSize.Desktop` gate the member drawer uses).
+
+## 2. Current state (source-grounded, v4.12.6)
+
+- **Threads are inline in the room timeline.** There is no thread component anywhere in
+  `src/` (`find src -iname '*thread*'` returns nothing under `components/`/`features/`).
+  Thread logic lives inside `RoomTimeline.tsx`, `message/Message.tsx`, and `message/Reply.tsx`.
+- A message is a threaded event iff `mEvent.threadRootId !== undefined`.
+- `Reply.tsx` renders a clickable **`ThreadIndicator`** (Icon `Thread` + "Thread" label,
+  `data-event-id={threadRootId}`, `onClick{handleOpenReply}`). Today `handleOpenReply` only
+  **scrolls to the root** in the main timeline — there is no dedicated thread view.
+- **Start a thread:** `Message.tsx` "Reply in Thread" (`Icons.ThreadPlus`) →
+  `RoomTimeline.handleReplyClick(evt, true)` sets a reply draft with relation
+  `{ rel_type: 'm.thread', event_id: replyId }` and focuses the composer.
+- **Panel host:** `src/app/features/room/Room.tsx` renders a horizontal `Box`:
+  `RoomView` (grow) → optional `Line` divider → `MembersDrawer` (`shrink="No"`),
+  gated on `screenSize === ScreenSize.Desktop && isDrawer`.
+- **Member drawer template:** `MembersDrawer.tsx` (442 lines) — `Header` v600 with a Close
+  `IconButton` (`Icons.Cross`) that `setPeopleDrawer(false)`, inner `Box shrink="No" direction="Column"`,
+  `Scroll` + `useVirtualizer` (`@tanstack/react-virtual`), `useAsyncSearch`+`useDebounce` filtering,
+  `Chip` filter/sort `PopOut` menus, `ScrollTopContainer`, `Spinner` while fetching.
+  CSS in `MembersDrawer.css.ts`; container color via `ContainerColor` from `styles/ContainerColor.css`.
+- **Settings model:** `src/app/state/settings.ts` — Jotai `atom` persisted to localStorage
+  (`STORAGE_KEY = 'settings'`), a `Settings` interface + `defaultSettings` object.
+  UI: `features/settings/general/General.tsx` uses `SettingTile` + `Switch` together with
+  `useSetting(settingsAtom, key)` / `useSetSetting`. Example: `isPeopleDrawer` (default `true`).
+
+## 3. Design
+
+### 3.1 New setting
+
+Add to `src/app/state/settings.ts`:
+
+```ts
+// interface Settings
+threadsDrawer: boolean;
+
+// defaultSettings
+threadsDrawer: false,
+```
+
+Add a `SettingTile` + `Switch` (title `Threads`, hint "Show threads side panel") in
+`features/settings/general/General.tsx`, next to the `isPeopleDrawer`-style toggles
+(under Appearance / People area).
+
+### 3.2 New `ThreadsDrawer` component
+
+New file `src/app/features/room/ThreadsDrawer.tsx` (+ `ThreadsDrawer.css.ts`), modeled on
+`MembersDrawer`. Props: `{ room: Room }` (no external members fetch needed — threads come
+from the room). Structure:
+
+```
+Header v600: "<N> Threads" + Close (Icons.Cross) -> setThreadsDrawer(false)
+Scroll
+  ThreadScroller list (virtualized): one entry per thread root
+    root avatar/sender + snippet (body, scaled emoji)
+    last-activity / unread badge (from roomToUnreadAtom / useRoomUnread)
+  empty-state: "No threads" Text when none
+  Spinner while the thread set is still being fetched/paginated
+Clicking a thread -> setSelectedThread(threadId) -> detail view replaces the list
+Detail view:
+  back arrow to list, root message header
+  thread timeline rendered with existing message renderers (see 3.4)
+  (MVP) read-only; reply-in-panel is a follow-up
+```
+
+### 3.3 Mount in `Room.tsx`
+
+Alongside the member drawer, in the right-column slot:
+
+```tsx
+{!callView && screenSize === ScreenSize.Desktop && (isDrawer || threadsDrawer) && (
+  <>
+    <Line variant="Background" direction="Vertical" size="300" />
+    {threadsDrawer ? <ThreadsDrawer key={room.roomId} room={room} /> : <MembersDrawer ... />}
+  </>
+)}
+```
+
+Because only one can show at a time, opening `threadsDrawer` should toggle `isPeopleDrawer`
+off and vice-versa (a header/room-view affordance will swap them). This keeps the two
+right-panels mutually exclusive without layout conflicts.
+
+### 3.4 Rendering a thread's events
+
+The existing `useMatrixEventRenderer` message renderers (`MessageEvent.RoomMessage`,
+`RoomMessageEncrypted`, `Sticker`, etc.) already take a `timelineSet` argument and pass
+`replyEventId`/`threadRootId` through. So the thread detail view can reuse them by supplying
+the thread's `EventTimelineSet` (from the SDK thread object) instead of the room's unfiltered
+set. Confirm exact SDK accessor at `npm ci` time:
+- `room.getThreads()` → `Thread[]` (or per-timeline enumeration) for the list,
+- thread object's live timeline / `EventTimelineSet` for the detail view.
+
+### 3.5 Data, sync, and unread
+
+- **Enumeration:** threads are per-room; root event + last message come from the SDK thread
+  structures (Threads MSC). Live updates via existing room sync events.
+- **Freshness:** thread roots that are not pre-loaded may require the room's client event
+  timeline to include them. If `room.getThreads()` is not fully populated in the common case,
+  add a `client.getThreadsForRoom`-style call or iterate the unfiltered timeline for
+  `m.thread` relations. (Decide at implementation after SDK inspection.)
+- **Unread:** reuse `src/app/state/room/roomToUnread.ts` + `src/app/state/hooks/unread.ts`
+  (`useRoomUnread`) and the same `markAsRead` utility the room uses.
+
+## 4. Risks / decisions
+
+| Risk | Mitigation |
+|------|------------|
+| Thread enumeration not fully populated in SDK | Verify `room.getThreads()`/relation walk on a real room early (spike) |
+| Mutually-exclusive drawers UX | Swap setting on open; keep single right-column slot |
+| Mobile | Gate on `ScreenSize.Desktop` like `MembersDrawer` |
+| Reusing inline-fragile renderers in a panel | Only feed the detail view the thread timelineSet; no changes to main timeline paths |
+| Reply-from-panel (heavier) | Defer to follow-up; MVP read-only |
+| Fork maintenance (no upstream PRs accepted) | Pin at `baseline-v4.12.6`, rebase only on explicit request |
+
+## 5. Acceptance (MVP)
+
+- [x] `Threads` toggle appears in General settings, persists across reloads.
+- [x] Enabling it on desktop shows the thread drawer instead of the member drawer.
+- [x] Drawer lists a real room's threads (snippet + reply count), with server-side list bootstrapped via `room.createThreadsTimelineSets()`.
+- [x] Clicking a thread shows its events (root + replies, rendered with the same `Message`/`RenderMessageContent` the main timeline uses) in the panel; back arrow returns to the list.
+- [x] Close (Cross) turns the drawer off; member drawer returns to its prior state (drawers are mutually exclusive via the header toggles).
+- [ ] Live per-thread unread badge (thread-level unread computed from read marker) — follow-up.
+- [ ] Reply in-thread from the detail view — follow-up.
+
+## 6. Implementation status (2026-08-18)
+
+Implemented on `feature/threads-panel` (forked from `baseline-v4.12.6` @ `33f4ba3`):
+- `src/app/state/settings.ts` — `threadsDrawer` setting (default `false`).
+- `src/app/features/settings/general/General.tsx` — `Threads` toggle in Appearance.
+- `src/app/features/room/ThreadsDrawer.tsx` + `ThreadsDrawer.css.ts` — thread list + detail sub-view.
+- `src/app/features/room/Room.tsx` — mounts the drawer (desktop, mutually exclusive with member drawer).
+- `src/app/features/room/RoomViewHeader.tsx` — desktop Threads button toggling the drawer.
+Verified: `npm run build` passes (exit 0); `npm run build` produces a new `dist` bundle; `npx eslint` and `prettier --check` clean on changed files. `tsc --noEmit` fails repo-wide at baseline (798 pre-existing errors from `matrix-js-sdk` ESM type resolution under `moduleResolution: Node`) — not regressions from this change; the shipping gate is `vite build`, which passes.

--- a/docs/thread-panel-rfc.md
+++ b/docs/thread-panel-rfc.md
@@ -147,3 +147,70 @@ Implemented on `feature/threads-panel` (forked from `baseline-v4.12.6` @ `33f4ba
 - `src/app/features/room/Room.tsx` — mounts the drawer (desktop, mutually exclusive with member drawer).
 - `src/app/features/room/RoomViewHeader.tsx` — desktop Threads button toggling the drawer.
 Verified: `npm run build` passes (exit 0); `npm run build` produces a new `dist` bundle; `npx eslint` and `prettier --check` clean on changed files. `tsc --noEmit` fails repo-wide at baseline (798 pre-existing errors from `matrix-js-sdk` ESM type resolution under `moduleResolution: Node`) — not regressions from this change; the shipping gate is `vite build`, which passes.
+
+## 7. Post-deploy bug — threads labeled in timeline but missing from the panel
+
+**Symptom:** messages user replies to carry the `Thread` indicator in the timeline, but the
+panel lists few/no threads (including the one just started).
+
+### 7.1 Root cause (confirmed in matrix-js-sdk 41.7.0 source)
+
+Cinny never enables `client.supportsThreads()`, so the SDK's **entire server-side thread
+aggregation path is dead code**:
+
+1. `client.supportsThreads()` returns `clientOpts.threadSupport || false`. Cinny never sets
+   it (grep of `src/` = zero hits) before this fix.
+2. With it `false`:
+   - `room.createThreadsTimelineSets()` returns `null` immediately
+     (`room.js` `if (this.client.supportsThreads())` gate).
+   - `client.processThreadRoots(...)` early-returns (`if (!this.supportsThreads()) return;`
+     at `client.js:7273`) — so even paginating a thread-list timeline set never registers
+     roots into `room.threads`.
+   - `room.getThreads()` therefore contains only threads whose events arrived in the
+     sync'd timeline window — an incomplete set for an active room.
+3. Meanwhile the `Thread` label still appears in the timeline because Cinny detects
+   `rel_type: 'm.thread'` client-side from `mEvent.threadRootId` (independent of
+   `supportsThreads()`). Hence "labeled but not listed."
+
+### 7.2 The authentic fix — enable SDK thread support at startup
+
+`threadSupport` is an `IStartClientOpts` field (NOT a `createClient` opt). Set it where
+the authenticated client starts:
+
+```ts
+// src/client/initMatrix.ts
+await mx.startClient({ lazyLoadMembers: true, threadSupport: true });
+```
+
+This single flag flips on: server thread-list (`/threads` via `createThreadsTimelineSets`),
+`processThreadRoots` registration, per-thread `EventTimelineSet`s, and thread receipts. The
+panel then consumes the SDK's canonical structures instead of re-implementing layout.
+
+### 7.3 Authentic data flow (mirrors the SDK/Element model — no polling)
+
+- **Client enable:** `threadSupport: true` on `startClient` (see 7.2) un-gates every SDK
+  thread-list primitive.
+- **List source:** `room.fetchRoomThreads()` (public `room.d.ts:845`, *no auto-caller* — the
+  app must invoke it). It fetches `/threads` (All + My), sorts roots by last-reply time,
+  registers each into `room.threads` via `processThreadRoots` (firing `ThreadEvent.New`),
+  and sets `threadsReady`. The panel keeps state fresh from `room.getThreads()` and
+  `ThreadEvent.New/NewReply/Update/Delete`.
+- **List reply counts:** correct on first render because `createThread` → `processRootEvent`
+  reads the bundled `m.thread` relation `count` into `Thread.length` (thread.js:461).
+- **Live updates (list + detail):** subscribe on the ROOM to `RoomEvent.Timeline` /
+  `TimelineRefresh` / `Redaction` (the room re-emits each thread timeline set's events via
+  its re-emitter) and bump a `revision` state the events memo depends on — the same
+  event-driven model `RoomTimeline.tsx` uses (`useLiveEventArrive`, `useLiveTimelineRefresh`).
+  NOT a forced `ticks` loop.
+- **Detail view:** render `thread.rootEvent` + `thread.timelineSet` via the existing message
+  renderers; a thread created from the server list starts with an empty-ish timeline, so
+  backfill it on open with `mx.paginateEventTimeline(thread.timelineSet.getLiveTimeline(),
+  {backwards:true,limit})` (the timeline set's `.thread` drives `/messages` + thread filter).
+
+### 7.4 Defers / known-good discipline
+
+- Per-thread unread computed from read marker — follow-up.
+- Reply-in-panel — follow-up.
+- No `tsc` clean gate exists at baseline (798 pre-existing SDK ESM-type errors); the
+  shipping gate is `vite build` (passes) + `eslint` + `prettier`. Do not widen the
+  `tsc` noise.

--- a/src/app/features/room/Room.tsx
+++ b/src/app/features/room/Room.tsx
@@ -5,6 +5,7 @@ import { isKeyHotkey } from 'is-hotkey';
 import { useAtomValue } from 'jotai';
 import { RoomView } from './RoomView';
 import { MembersDrawer } from './MembersDrawer';
+import { ThreadsDrawer } from './ThreadsDrawer';
 import { ScreenSize, useScreenSizeContext } from '../../hooks/useScreenSize';
 import { useSetting } from '../../state/hooks/settings';
 import { settingsAtom } from '../../state/settings';
@@ -31,6 +32,7 @@ export function Room() {
   const callEmbed = useCallEmbed();
 
   const [isDrawer] = useSetting(settingsAtom, 'isPeopleDrawer');
+  const [threadsDrawer] = useSetting(settingsAtom, 'threadsDrawer');
   const [hideActivity] = useSetting(settingsAtom, 'hideActivity');
   const screenSize = useScreenSizeContext();
   const powerLevels = usePowerLevels(room);
@@ -79,10 +81,14 @@ export function Room() {
             <CallChatView />
           </>
         )}
-        {!callView && screenSize === ScreenSize.Desktop && isDrawer && (
+        {!callView && screenSize === ScreenSize.Desktop && (isDrawer || threadsDrawer) && (
           <>
             <Line variant="Background" direction="Vertical" size="300" />
-            <MembersDrawer key={room.roomId} room={room} members={members} />
+            {threadsDrawer ? (
+              <ThreadsDrawer key={room.roomId} room={room} />
+            ) : (
+              <MembersDrawer key={room.roomId} room={room} members={members} />
+            )}
           </>
         )}
       </Box>

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -1038,23 +1038,46 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
   // Keep thread summaries live: a new reply, thread update/delete, or a read
   // receipt changes the preview/reply-count/unread shown under root messages,
   // none of which flow through the main-room timeline events.
+  //
+  // We also listen for RoomEvent.LocalEchoUpdated: when the user sends a thread
+  // reply, the SDK's addLiveEvents() recognises the remote echo by its
+  // transaction_id and routes it through handleRemoteEcho(), which updates an
+  // existing thread but never CREATES one (it skips the addThreadedEvents path
+  // that createThread + ThreadEvent.New live on). So the Thread object for our
+  // own newly-started thread is never created live, and the summary under the
+  // root message never appears until a reload re-runs fetchRoomThreads().
+  // When the confirmed event is a thread reply whose Thread doesn't exist yet,
+  // we manually create it via processThreadRoots([rootEvent]), which calls
+  // createThread() and emits ThreadEvent.New — the onNew handler then bumps
+  // the revision and the ThreadSummary appears live.
   useEffect(() => {
     const bump = () => setThreadRevision((r) => r + 1);
     const onDelete = () => bump();
     const onNewReply = () => bump();
     const onUpdate = () => bump();
     const onNew = () => bump();
+    const onLocalEchoUpdated = (mEvent: MatrixEvent) => {
+      const rootId = mEvent.threadRootId;
+      if (rootId && !room.getThread(rootId)) {
+        const rootEvent = room.findEventById(rootId);
+        if (rootEvent) {
+          room.processThreadRoots([rootEvent], false);
+        }
+      }
+    };
     room.on(ThreadEvent.New as never, onNew as never);
     room.on(ThreadEvent.NewReply as never, onNewReply as never);
     room.on(ThreadEvent.Update as unknown as never, onUpdate as never);
     room.on(ThreadEvent.Delete as never, onDelete as never);
     room.on(RoomEvent.Receipt as never, bump as never);
+    room.on(RoomEvent.LocalEchoUpdated as never, onLocalEchoUpdated as never);
     return () => {
       room.off(ThreadEvent.New as never, onNew as never);
       room.off(ThreadEvent.NewReply as never, onNewReply as never);
       room.off(ThreadEvent.Update as unknown as never, onUpdate as never);
       room.off(ThreadEvent.Delete as never, onDelete as never);
       room.off(RoomEvent.Receipt as never, bump as never);
+      room.off(RoomEvent.LocalEchoUpdated as never, onLocalEchoUpdated as never);
     };
   }, [room]);
 

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -449,6 +449,7 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
   const showUrlPreview = room.hasEncryptionStateEvent() ? encUrlPreview : urlPreview;
   const [showHiddenEvents] = useSetting(settingsAtom, 'showHiddenEvents');
   const [showDeveloperTools] = useSetting(settingsAtom, 'developerTools');
+  const [threadsDrawer] = useSetting(settingsAtom, 'threadsDrawer');
 
   const [hour24Clock] = useSetting(settingsAtom, 'hour24Clock');
   const [dateFormatString] = useSetting(settingsAtom, 'dateFormatString');
@@ -1176,7 +1177,7 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
                 />
               )}
             </Message>
-            {threadRoot && (
+            {threadRoot && threadsDrawer && (
               <ThreadSummary
                 room={room}
                 thread={threadRoot}

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -1043,11 +1043,14 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
     const onDelete = () => bump();
     const onNewReply = () => bump();
     const onUpdate = () => bump();
+    const onNew = () => bump();
+    room.on(ThreadEvent.New as never, onNew as never);
     room.on(ThreadEvent.NewReply as never, onNewReply as never);
     room.on(ThreadEvent.Update as unknown as never, onUpdate as never);
     room.on(ThreadEvent.Delete as never, onDelete as never);
     room.on(RoomEvent.Receipt as never, bump as never);
     return () => {
+      room.off(ThreadEvent.New as never, onNew as never);
       room.off(ThreadEvent.NewReply as never, onNewReply as never);
       room.off(ThreadEvent.Update as unknown as never, onUpdate as never);
       room.off(ThreadEvent.Delete as never, onDelete as never);

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -22,6 +22,7 @@ import {
   Room,
   RoomEvent,
   RoomEventHandlerMap,
+  ThreadEvent,
 } from 'matrix-js-sdk';
 import { HTMLReactParserOptions } from 'html-react-parser';
 import classNames from 'classnames';
@@ -83,9 +84,11 @@ import {
   isMembershipChanged,
   reactionOrEditEvent,
 } from '../../utils/room';
-import { useSetting } from '../../state/hooks/settings';
+import { useSetting, useSetSetting } from '../../state/hooks/settings';
 import { MessageLayout, settingsAtom } from '../../state/settings';
+import { selectedThreadAtom } from '../../state/room/threadSelection';
 import { useMatrixEventRenderer } from '../../hooks/useMatrixEventRenderer';
+import { ThreadSummary } from './ThreadSummary';
 import { Reactions, Message, Event, EncryptedContent } from './message';
 import { useMemberEventParser } from '../../hooks/useMemberEventParser';
 import * as customHtmlCss from '../../styles/CustomHtml.css';
@@ -456,6 +459,18 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
   const setReplyDraft = useSetAtom(roomIdToReplyDraftAtomFamily(room.roomId));
   const powerLevels = usePowerLevelsContext();
   const creators = useRoomCreators(room);
+  const setThreadsDrawer = useSetSetting(settingsAtom, 'threadsDrawer');
+  const setSelectedThread = useSetAtom(selectedThreadAtom);
+
+  const handleOpenThread = useCallback(
+    (threadId: string) => {
+      // Open the threads drawer and select the given thread so the summary's
+      // click lands on that thread's conversation inside the panel.
+      setThreadsDrawer(true);
+      setSelectedThread({ roomId: room.roomId, threadId });
+    },
+    [room.roomId, setSelectedThread, setThreadsDrawer]
+  );
 
   const creatorsTag = useRoomCreatorsTag();
   const powerLevelTags = usePowerLevelTags(room, powerLevels);
@@ -475,6 +490,9 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
   const canSendReaction = permissions.event(MessageEvent.Reaction, mx.getSafeUserId());
   const canPinEvent = permissions.stateEvent(StateEvent.RoomPinnedEvents, mx.getSafeUserId());
   const [editId, setEditId] = useState<string>();
+  // Bumped when thread data (new reply / update / delete / receipt) changes so
+  // thread summaries under root messages re-render with fresh preview + unread.
+  const [, setThreadRevision] = useState(0);
 
   const roomToParents = useAtomValue(roomToParentsAtom);
   const unread = useRoomUnread(room.roomId, roomToUnreadAtom);
@@ -1017,6 +1035,26 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
   );
   const { t } = useTranslation();
 
+  // Keep thread summaries live: a new reply, thread update/delete, or a read
+  // receipt changes the preview/reply-count/unread shown under root messages,
+  // none of which flow through the main-room timeline events.
+  useEffect(() => {
+    const bump = () => setThreadRevision((r) => r + 1);
+    const onDelete = () => bump();
+    const onNewReply = () => bump();
+    const onUpdate = () => bump();
+    room.on(ThreadEvent.NewReply as never, onNewReply as never);
+    room.on(ThreadEvent.Update as unknown as never, onUpdate as never);
+    room.on(ThreadEvent.Delete as never, onDelete as never);
+    room.on(RoomEvent.Receipt as never, bump as never);
+    return () => {
+      room.off(ThreadEvent.NewReply as never, onNewReply as never);
+      room.off(ThreadEvent.Update as unknown as never, onUpdate as never);
+      room.off(ThreadEvent.Delete as never, onDelete as never);
+      room.off(RoomEvent.Receipt as never, bump as never);
+    };
+  }, [room]);
+
   const renderMatrixEvent = useMatrixEventRenderer<
     [string, MatrixEvent, number, EventTimelineSet, boolean]
   >(
@@ -1035,80 +1073,91 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
         const senderId = mEvent.getSender() ?? '';
         const senderDisplayName =
           getMemberDisplayName(room, senderId) ?? getMxIdLocalPart(senderId) ?? senderId;
+        // A message is a thread root if it has a matching Thread object in the room.
+        const threadRoot = room.getThread(mEventId);
 
         return (
-          <Message
-            key={mEvent.getId()}
-            data-message-item={item}
-            data-message-id={mEventId}
-            room={room}
-            mEvent={mEvent}
-            messageSpacing={messageSpacing}
-            messageLayout={messageLayout}
-            collapse={collapse}
-            highlight={highlighted}
-            edit={editId === mEventId}
-            canDelete={canRedact || (canDeleteOwn && mEvent.getSender() === mx.getUserId())}
-            canSendReaction={canSendReaction}
-            canPinEvent={canPinEvent}
-            imagePackRooms={imagePackRooms}
-            relations={hasReactions ? reactionRelations : undefined}
-            onUserClick={handleUserClick}
-            onUsernameClick={handleUsernameClick}
-            onReplyClick={handleReplyClick}
-            onReactionToggle={handleReactionToggle}
-            onEditId={handleEdit}
-            reply={
-              replyEventId && (
-                <Reply
-                  room={room}
-                  timelineSet={timelineSet}
-                  replyEventId={replyEventId}
-                  threadRootId={threadRootId}
-                  onClick={handleOpenReply}
-                  getMemberPowerTag={getMemberPowerTag}
-                  accessibleTagColors={accessiblePowerTagColors}
-                  legacyUsernameColor={legacyUsernameColor || direct}
+          <React.Fragment key={mEvent.getId()}>
+            <Message
+              key={mEvent.getId()}
+              data-message-item={item}
+              data-message-id={mEventId}
+              room={room}
+              mEvent={mEvent}
+              messageSpacing={messageSpacing}
+              messageLayout={messageLayout}
+              collapse={collapse}
+              highlight={highlighted}
+              edit={editId === mEventId}
+              canDelete={canRedact || (canDeleteOwn && mEvent.getSender() === mx.getUserId())}
+              canSendReaction={canSendReaction}
+              canPinEvent={canPinEvent}
+              imagePackRooms={imagePackRooms}
+              relations={hasReactions ? reactionRelations : undefined}
+              onUserClick={handleUserClick}
+              onUsernameClick={handleUsernameClick}
+              onReplyClick={handleReplyClick}
+              onReactionToggle={handleReactionToggle}
+              onEditId={handleEdit}
+              reply={
+                replyEventId && (
+                  <Reply
+                    room={room}
+                    timelineSet={timelineSet}
+                    replyEventId={replyEventId}
+                    threadRootId={threadRootId}
+                    onClick={handleOpenReply}
+                    getMemberPowerTag={getMemberPowerTag}
+                    accessibleTagColors={accessiblePowerTagColors}
+                    legacyUsernameColor={legacyUsernameColor || direct}
+                  />
+                )
+              }
+              reactions={
+                reactionRelations && (
+                  <Reactions
+                    style={{ marginTop: config.space.S200 }}
+                    room={room}
+                    relations={reactionRelations}
+                    mEventId={mEventId}
+                    canSendReaction={canSendReaction}
+                    onReactionToggle={handleReactionToggle}
+                  />
+                )
+              }
+              hideReadReceipts={hideActivity}
+              showDeveloperTools={showDeveloperTools}
+              memberPowerTag={getMemberPowerTag(senderId)}
+              accessibleTagColors={accessiblePowerTagColors}
+              legacyUsernameColor={legacyUsernameColor || direct}
+              hour24Clock={hour24Clock}
+              dateFormatString={dateFormatString}
+            >
+              {mEvent.isRedacted() ? (
+                <RedactedContent reason={mEvent.getUnsigned().redacted_because?.content.reason} />
+              ) : (
+                <RenderMessageContent
+                  displayName={senderDisplayName}
+                  msgType={mEvent.getContent().msgtype ?? ''}
+                  ts={mEvent.getTs()}
+                  edited={!!editedEvent}
+                  getContent={getContent}
+                  mediaAutoLoad={mediaAutoLoad}
+                  urlPreview={showUrlPreview}
+                  htmlReactParserOptions={htmlReactParserOptions}
+                  linkifyOpts={linkifyOpts}
+                  outlineAttachment={messageLayout === MessageLayout.Bubble}
                 />
-              )
-            }
-            reactions={
-              reactionRelations && (
-                <Reactions
-                  style={{ marginTop: config.space.S200 }}
-                  room={room}
-                  relations={reactionRelations}
-                  mEventId={mEventId}
-                  canSendReaction={canSendReaction}
-                  onReactionToggle={handleReactionToggle}
-                />
-              )
-            }
-            hideReadReceipts={hideActivity}
-            showDeveloperTools={showDeveloperTools}
-            memberPowerTag={getMemberPowerTag(senderId)}
-            accessibleTagColors={accessiblePowerTagColors}
-            legacyUsernameColor={legacyUsernameColor || direct}
-            hour24Clock={hour24Clock}
-            dateFormatString={dateFormatString}
-          >
-            {mEvent.isRedacted() ? (
-              <RedactedContent reason={mEvent.getUnsigned().redacted_because?.content.reason} />
-            ) : (
-              <RenderMessageContent
-                displayName={senderDisplayName}
-                msgType={mEvent.getContent().msgtype ?? ''}
-                ts={mEvent.getTs()}
-                edited={!!editedEvent}
-                getContent={getContent}
-                mediaAutoLoad={mediaAutoLoad}
-                urlPreview={showUrlPreview}
-                htmlReactParserOptions={htmlReactParserOptions}
-                linkifyOpts={linkifyOpts}
-                outlineAttachment={messageLayout === MessageLayout.Bubble}
+              )}
+            </Message>
+            {threadRoot && (
+              <ThreadSummary
+                room={room}
+                thread={threadRoot}
+                onOpen={() => handleOpenThread(threadRoot.id)}
               />
             )}
-          </Message>
+          </React.Fragment>
         );
       },
       [MessageEvent.RoomMessageEncrypted]: (mEventId, mEvent, item, timelineSet, collapse) => {

--- a/src/app/features/room/RoomViewHeader.tsx
+++ b/src/app/features/room/RoomViewHeader.tsx
@@ -416,6 +416,7 @@ export function RoomViewHeader({ callView }: { callView?: boolean }) {
     : undefined;
 
   const [peopleDrawer, setPeopleDrawer] = useSetting(settingsAtom, 'isPeopleDrawer');
+  const [threadsDrawer, setThreadsDrawer] = useSetting(settingsAtom, 'threadsDrawer');
 
   const handleSearchClick = () => {
     const searchParams: _SearchPathSearchParams = {
@@ -443,6 +444,12 @@ export function RoomViewHeader({ callView }: { callView?: boolean }) {
       return;
     }
     setPeopleDrawer(!peopleDrawer);
+    setThreadsDrawer(false);
+  };
+
+  const handleThreadsToggle = () => {
+    setThreadsDrawer(!threadsDrawer);
+    if (!threadsDrawer) setPeopleDrawer(false);
   };
 
   return (
@@ -597,6 +604,24 @@ export function RoomViewHeader({ callView }: { callView?: boolean }) {
           {!room.isCallRoom() && livekitSupported && rtcSupported && hasCallPermission && (
             <CallButton />
           )}
+          {screenSize === ScreenSize.Desktop && (
+            <TooltipProvider
+              position="Bottom"
+              offset={4}
+              tooltip={
+                <Tooltip>
+                  <Text>{threadsDrawer ? 'Hide Threads' : 'Show Threads'}</Text>
+                </Tooltip>
+              }
+            >
+              {(triggerRef) => (
+                <IconButton fill="None" ref={triggerRef} onClick={handleThreadsToggle}>
+                  <Icon size="400" src={Icons.Thread} />
+                </IconButton>
+              )}
+            </TooltipProvider>
+          )}
+
           {screenSize === ScreenSize.Desktop && (
             <TooltipProvider
               position="Bottom"

--- a/src/app/features/room/ThreadReplyInput.tsx
+++ b/src/app/features/room/ThreadReplyInput.tsx
@@ -1,7 +1,14 @@
-import React, { KeyboardEventHandler, useCallback, useEffect } from 'react';
-import { Box, Icon, IconButton, Icons, Line, config } from 'folds';
+import React, {
+  KeyboardEventHandler,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { Box, Icon, IconButton, Icons, Line, PopOut, config } from 'folds';
 import { isKeyHotkey } from 'is-hotkey';
 import {
+  EventType,
   IContent,
   MsgType,
   NotificationCountType,
@@ -9,13 +16,16 @@ import {
   Room,
   Thread,
 } from 'matrix-js-sdk';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { ReactEditor } from 'slate-react';
 import { Transforms } from 'slate';
 
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import {
+  createEmoticonElement,
   CustomEditor,
+  moveCursor,
+  getMentions,
   Toolbar,
   toMatrixCustomHTML,
   toPlainText,
@@ -25,13 +35,20 @@ import {
   isEmptyEditor,
   trimCustomHtml,
   customHtmlEqualsPlainText,
-  getMentions,
 } from '../../components/editor';
+import { EmojiBoard, EmojiBoardTab } from '../../components/emoji-board';
+import { UseStateProvider } from '../../components/UseStateProvider';
 import { useSetting } from '../../state/hooks/settings';
 import { settingsAtom } from '../../state/settings';
 import { getMentionContent } from '../../utils/room';
 import { threadIdToMsgDraftAtomFamily } from '../../state/room/roomInputDrafts';
 import { useComposingCheck } from '../../hooks/useComposingCheck';
+import { useMediaAuthentication } from '../../hooks/useMediaAuthentication';
+import { useImagePackRooms } from '../../hooks/useImagePackRooms';
+import { roomToParentsAtom } from '../../state/room/roomToParents';
+import { getImageInfo, mxcUrlToHttp } from '../../utils/matrix';
+import { getImageUrlBlob, loadImageElement } from '../../utils/dom';
+import { mobileOrTablet } from '../../utils/user-agent';
 
 /**
  * Reply composer for the thread panel. Persists its draft per-thread (not the
@@ -47,6 +64,12 @@ function ThreadReplyInput({ room, thread }: { room: Room; thread: Thread }) {
   const [toolbar, setToolbar] = useSetting(settingsAtom, 'editorToolbar');
   const [msgDraft, setMsgDraft] = useAtom(threadIdToMsgDraftAtomFamily(thread.id));
   const isComposing = useComposingCheck();
+
+  const emojiBtnRef = useRef<HTMLButtonElement>(null);
+  const useAuthentication = useMediaAuthentication();
+  const roomToParents = useAtomValue(roomToParentsAtom);
+  const imagePackRooms: Room[] = useImagePackRooms(room.roomId, roomToParents);
+  const [hideStickerBtn] = useState(document.body.clientWidth < 500);
 
   const rootEventId = thread.rootEvent?.getId();
 
@@ -120,6 +143,34 @@ function ThreadReplyInput({ room, thread }: { room: Room; thread: Thread }) {
     [submit, enterForNewline, isComposing]
   );
 
+  const handleEmoticonSelect = (key: string, shortcode: string) => {
+    editor.insertNode(createEmoticonElement(key, shortcode));
+    moveCursor(editor);
+  };
+
+  const handleStickerSelect = async (mxc: string, shortcode: string, label: string) => {
+    if (!rootEventId) return;
+    const stickerUrl = mxcUrlToHttp(mx, mxc, useAuthentication);
+    if (!stickerUrl) return;
+
+    const info = await getImageInfo(
+      await loadImageElement(stickerUrl),
+      await getImageUrlBlob(stickerUrl)
+    );
+
+    await mx.sendEvent(room.roomId, EventType.Sticker, {
+      body: label,
+      url: mxc,
+      info,
+      'm.relates_to': {
+        rel_type: RelationType.Thread,
+        event_id: rootEventId,
+        is_falling_back: false,
+      },
+    });
+    room.setThreadUnreadNotificationCount(thread.id, NotificationCountType.Total, 0);
+  };
+
   return (
     <Box direction="Column" style={{ padding: `${config.space.S200} ${config.space.S300}` }}>
       <CustomEditor
@@ -133,14 +184,83 @@ function ThreadReplyInput({ room, thread }: { room: Room; thread: Thread }) {
           </IconButton>
         }
         after={
-          <IconButton
-            variant="SurfaceVariant"
-            size="300"
-            radii="300"
-            onClick={() => setToolbar(!toolbar)}
-          >
-            <Icon src={toolbar ? Icons.AlphabetUnderline : Icons.Alphabet} />
-          </IconButton>
+          <UseStateProvider initial={undefined}>
+            {(emojiBoardTab: EmojiBoardTab | undefined, setEmojiBoardTab) => (
+              <>
+                <IconButton
+                  variant="SurfaceVariant"
+                  size="300"
+                  radii="300"
+                  onClick={() => setToolbar(!toolbar)}
+                >
+                  <Icon src={toolbar ? Icons.AlphabetUnderline : Icons.Alphabet} />
+                </IconButton>
+                <PopOut
+                  offset={16}
+                  alignOffset={-44}
+                  position="Top"
+                  align="End"
+                  anchor={
+                    emojiBoardTab === undefined
+                      ? undefined
+                      : emojiBtnRef.current?.getBoundingClientRect() ?? undefined
+                  }
+                  content={
+                    <EmojiBoard
+                      tab={emojiBoardTab}
+                      onTabChange={setEmojiBoardTab}
+                      imagePackRooms={imagePackRooms}
+                      returnFocusOnDeactivate={false}
+                      onEmojiSelect={handleEmoticonSelect}
+                      onCustomEmojiSelect={handleEmoticonSelect}
+                      onStickerSelect={handleStickerSelect}
+                      requestClose={() => {
+                        setEmojiBoardTab((t) => {
+                          if (t) {
+                            if (!mobileOrTablet()) ReactEditor.focus(editor);
+                            return undefined;
+                          }
+                          return t;
+                        });
+                      }}
+                    />
+                  }
+                >
+                  {!hideStickerBtn && (
+                    <IconButton
+                      aria-pressed={emojiBoardTab === EmojiBoardTab.Sticker}
+                      onClick={() => setEmojiBoardTab(EmojiBoardTab.Sticker)}
+                      variant="SurfaceVariant"
+                      size="300"
+                      radii="300"
+                    >
+                      <Icon
+                        src={Icons.Sticker}
+                        filled={emojiBoardTab === EmojiBoardTab.Sticker}
+                      />
+                    </IconButton>
+                  )}
+                  <IconButton
+                    ref={emojiBtnRef}
+                    aria-pressed={
+                      hideStickerBtn ? !!emojiBoardTab : emojiBoardTab === EmojiBoardTab.Emoji
+                    }
+                    onClick={() => setEmojiBoardTab(EmojiBoardTab.Emoji)}
+                    variant="SurfaceVariant"
+                    size="300"
+                    radii="300"
+                  >
+                    <Icon
+                      src={Icons.Smile}
+                      filled={
+                        hideStickerBtn ? !!emojiBoardTab : emojiBoardTab === EmojiBoardTab.Emoji
+                      }
+                    />
+                  </IconButton>
+                </PopOut>
+              </>
+            )}
+          </UseStateProvider>
         }
         bottom={
           toolbar && (

--- a/src/app/features/room/ThreadReplyInput.tsx
+++ b/src/app/features/room/ThreadReplyInput.tsx
@@ -22,10 +22,17 @@ import { Transforms } from 'slate';
 
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import {
+  AutocompletePrefix,
+  AutocompleteQuery,
+  AUTOCOMPLETE_PREFIXES,
   createEmoticonElement,
   CustomEditor,
-  moveCursor,
+  EmoticonAutocomplete,
+  getAutocompleteQuery,
   getMentions,
+  getPrevWorldRange,
+  moveCursor,
+  RoomMentionAutocomplete,
   Toolbar,
   toMatrixCustomHTML,
   toPlainText,
@@ -35,6 +42,7 @@ import {
   isEmptyEditor,
   trimCustomHtml,
   customHtmlEqualsPlainText,
+  UserMentionAutocomplete,
 } from '../../components/editor';
 import { EmojiBoard, EmojiBoardTab } from '../../components/emoji-board';
 import { UseStateProvider } from '../../components/UseStateProvider';
@@ -72,6 +80,8 @@ function ThreadReplyInput({ room, thread }: { room: Room; thread: Thread }) {
   const [hideStickerBtn] = useState(document.body.clientWidth < 500);
 
   const rootEventId = thread.rootEvent?.getId();
+  const [autocompleteQuery, setAutocompleteQuery] =
+    useState<AutocompleteQuery<AutocompletePrefix>>();
 
   useEffect(() => {
     Transforms.insertFragment(editor, msgDraft);
@@ -139,9 +149,41 @@ function ThreadReplyInput({ room, thread }: { room: Room; thread: Thread }) {
         evt.preventDefault();
         submit();
       }
+      if (isKeyHotkey('escape', evt)) {
+        evt.preventDefault();
+        if (autocompleteQuery) {
+          setAutocompleteQuery(undefined);
+        }
+      }
     },
-    [submit, enterForNewline, isComposing]
+    [submit, enterForNewline, isComposing, autocompleteQuery]
   );
+
+  // Detect @mention / #room / :emoji autocomplete triggers as the user types,
+  // mirroring RoomInput so @max becomes a mention pill via the autocomplete UI.
+  const handleKeyUp: KeyboardEventHandler = useCallback(
+    (evt) => {
+      if (isKeyHotkey('escape', evt)) {
+        evt.preventDefault();
+        return;
+      }
+      const prevWordRange = getPrevWorldRange(editor);
+      const query = prevWordRange
+        ? getAutocompleteQuery<AutocompletePrefix>(
+            editor,
+            prevWordRange,
+            AUTOCOMPLETE_PREFIXES
+          )
+        : undefined;
+      setAutocompleteQuery(query);
+    },
+    [editor]
+  );
+
+  const handleCloseAutocomplete = useCallback(() => {
+    setAutocompleteQuery(undefined);
+    ReactEditor.focus(editor);
+  }, [editor]);
 
   const handleEmoticonSelect = (key: string, shortcode: string) => {
     editor.insertNode(createEmoticonElement(key, shortcode));
@@ -173,11 +215,36 @@ function ThreadReplyInput({ room, thread }: { room: Room; thread: Thread }) {
 
   return (
     <Box direction="Column" style={{ padding: `${config.space.S200} ${config.space.S300} 0` }}>
+      {autocompleteQuery?.prefix === AutocompletePrefix.RoomMention && (
+        <RoomMentionAutocomplete
+          roomId={room.roomId}
+          editor={editor}
+          query={autocompleteQuery}
+          requestClose={handleCloseAutocomplete}
+        />
+      )}
+      {autocompleteQuery?.prefix === AutocompletePrefix.UserMention && (
+        <UserMentionAutocomplete
+          room={room}
+          editor={editor}
+          query={autocompleteQuery}
+          requestClose={handleCloseAutocomplete}
+        />
+      )}
+      {autocompleteQuery?.prefix === AutocompletePrefix.Emoticon && (
+        <EmoticonAutocomplete
+          imagePackRooms={imagePackRooms}
+          editor={editor}
+          query={autocompleteQuery}
+          requestClose={handleCloseAutocomplete}
+        />
+      )}
       <CustomEditor
         editableName="ThreadReplyInput"
         editor={editor}
         placeholder="Reply to thread..."
         onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyUp}
         before={
           <IconButton onClick={submit} variant="SurfaceVariant" size="300" radii="300">
             <Icon src={Icons.Send} />

--- a/src/app/features/room/ThreadReplyInput.tsx
+++ b/src/app/features/room/ThreadReplyInput.tsx
@@ -1,0 +1,158 @@
+import React, { KeyboardEventHandler, useCallback, useEffect } from 'react';
+import { Box, Icon, IconButton, Icons, Line, config } from 'folds';
+import { isKeyHotkey } from 'is-hotkey';
+import {
+  IContent,
+  MsgType,
+  NotificationCountType,
+  RelationType,
+  Room,
+  Thread,
+} from 'matrix-js-sdk';
+import { useAtom } from 'jotai';
+import { ReactEditor } from 'slate-react';
+import { Transforms } from 'slate';
+
+import { useMatrixClient } from '../../hooks/useMatrixClient';
+import {
+  CustomEditor,
+  Toolbar,
+  toMatrixCustomHTML,
+  toPlainText,
+  resetEditor,
+  resetEditorHistory,
+  useEditor,
+  isEmptyEditor,
+  trimCustomHtml,
+  customHtmlEqualsPlainText,
+  getMentions,
+} from '../../components/editor';
+import { useSetting } from '../../state/hooks/settings';
+import { settingsAtom } from '../../state/settings';
+import { getMentionContent } from '../../utils/room';
+import { threadIdToMsgDraftAtomFamily } from '../../state/room/roomInputDrafts';
+import { useComposingCheck } from '../../hooks/useComposingCheck';
+
+/**
+ * Reply composer for the thread panel. Persists its draft per-thread (not the
+ * room-wide composer draft) and sends the message as a thread reply via
+ * `m.relates_to { rel_type: m.thread, event_id: <root> }` — the same shape
+ * RoomInput already uses for the thread branch of a reply.
+ */
+function ThreadReplyInput({ room, thread }: { room: Room; thread: Thread }) {
+  const mx = useMatrixClient();
+  const editor = useEditor();
+  const [enterForNewline] = useSetting(settingsAtom, 'enterForNewline');
+  const [isMarkdown] = useSetting(settingsAtom, 'isMarkdown');
+  const [toolbar, setToolbar] = useSetting(settingsAtom, 'editorToolbar');
+  const [msgDraft, setMsgDraft] = useAtom(threadIdToMsgDraftAtomFamily(thread.id));
+  const isComposing = useComposingCheck();
+
+  const rootEventId = thread.rootEvent?.getId();
+
+  useEffect(() => {
+    Transforms.insertFragment(editor, msgDraft);
+  }, [editor, msgDraft]);
+
+  useEffect(
+    () => () => {
+      if (!isEmptyEditor(editor)) {
+        const parsedDraft = JSON.parse(JSON.stringify(editor.children));
+        setMsgDraft(parsedDraft);
+      } else {
+        setMsgDraft([]);
+      }
+      resetEditor(editor);
+      resetEditorHistory(editor);
+    },
+    [thread.id, editor, setMsgDraft]
+  );
+
+  const submit = useCallback(() => {
+    if (!rootEventId) return;
+
+    const plainText = toPlainText(editor.children, isMarkdown).trim();
+    const formattedBody = trimCustomHtml(
+      toMatrixCustomHTML(editor.children, {
+        allowTextFormatting: true,
+        allowBlockMarkdown: isMarkdown,
+        allowInlineMarkdown: isMarkdown,
+      })
+    );
+    if (plainText === '') return;
+
+    const mentionData = getMentions(mx, room.roomId, editor);
+    const content: IContent = {
+      msgtype: MsgType.Text,
+      body: plainText,
+    };
+    content['m.mentions'] = getMentionContent(Array.from(mentionData.users), mentionData.room);
+    if (!customHtmlEqualsPlainText(formattedBody, plainText)) {
+      content.format = 'org.matrix.custom.html';
+      content.formatted_body = formattedBody;
+    }
+    content['m.relates_to'] = {
+      rel_type: RelationType.Thread,
+      event_id: rootEventId,
+      is_falling_back: false,
+    };
+
+    mx.sendMessage(room.roomId, content as any).then(() => {
+      // Best-effort thread read marker so the unread indicator clears.
+      room.setThreadUnreadNotificationCount(thread.id, NotificationCountType.Total, 0);
+    });
+    resetEditor(editor);
+    resetEditorHistory(editor);
+    setMsgDraft([]);
+    ReactEditor.focus(editor);
+  }, [editor, isMarkdown, mx, room, rootEventId, setMsgDraft, thread.id]);
+
+  const handleKeyDown: KeyboardEventHandler = useCallback(
+    (evt) => {
+      if (
+        (isKeyHotkey('mod+enter', evt) || (!enterForNewline && isKeyHotkey('enter', evt))) &&
+        !isComposing(evt)
+      ) {
+        evt.preventDefault();
+        submit();
+      }
+    },
+    [submit, enterForNewline, isComposing]
+  );
+
+  return (
+    <Box direction="Column" style={{ padding: `${config.space.S200} ${config.space.S300}` }}>
+      <CustomEditor
+        editableName="ThreadReplyInput"
+        editor={editor}
+        placeholder="Reply to thread..."
+        onKeyDown={handleKeyDown}
+        before={
+          <IconButton onClick={submit} variant="SurfaceVariant" size="300" radii="300">
+            <Icon src={Icons.Send} />
+          </IconButton>
+        }
+        after={
+          <IconButton
+            variant="SurfaceVariant"
+            size="300"
+            radii="300"
+            onClick={() => setToolbar(!toolbar)}
+          >
+            <Icon src={toolbar ? Icons.AlphabetUnderline : Icons.Alphabet} />
+          </IconButton>
+        }
+        bottom={
+          toolbar && (
+            <div>
+              <Line variant="SurfaceVariant" size="300" />
+              <Toolbar />
+            </div>
+          )
+        }
+      />
+    </Box>
+  );
+}
+
+export default ThreadReplyInput;

--- a/src/app/features/room/ThreadReplyInput.tsx
+++ b/src/app/features/room/ThreadReplyInput.tsx
@@ -172,7 +172,7 @@ function ThreadReplyInput({ room, thread }: { room: Room; thread: Thread }) {
   };
 
   return (
-    <Box direction="Column" style={{ padding: `${config.space.S200} ${config.space.S300}` }}>
+    <Box direction="Column" style={{ padding: `${config.space.S200} ${config.space.S300} 0` }}>
       <CustomEditor
         editableName="ThreadReplyInput"
         editor={editor}

--- a/src/app/features/room/ThreadSummary.css.ts
+++ b/src/app/features/room/ThreadSummary.css.ts
@@ -1,0 +1,35 @@
+import { style } from '@vanilla-extract/css';
+import { color, config, toRem } from 'folds';
+
+export const ThreadSummary = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: toRem(8),
+  width: 'fit-content',
+  maxWidth: '100%',
+  marginLeft: toRem(64),
+  padding: `${config.space.S100} ${config.space.S200}`,
+  border: 'none',
+  borderRadius: toRem(12),
+  background: 'transparent',
+  color: color.Surface.OnContainer,
+  cursor: 'pointer',
+  textAlign: 'left',
+  transition: 'background 0.15s ease, color 0.15s ease',
+  ':hover': {
+    background: color.Surface.Container,
+    color: color.SurfaceVariant.OnContainer,
+  },
+  ':focus-visible': {
+    outline: 'none',
+    background: color.Surface.Container,
+  },
+});
+
+export const ThreadSummaryUnread = style({
+  color: color.Success.Main,
+  ':hover': {
+    color: color.Success.Main,
+    background: color.Surface.Container,
+  },
+});

--- a/src/app/features/room/ThreadSummary.css.ts
+++ b/src/app/features/room/ThreadSummary.css.ts
@@ -25,11 +25,3 @@ export const ThreadSummary = style({
     background: color.Surface.Container,
   },
 });
-
-export const ThreadSummaryUnread = style({
-  color: color.Success.Main,
-  ':hover': {
-    color: color.Success.Main,
-    background: color.Surface.Container,
-  },
-});

--- a/src/app/features/room/ThreadSummary.tsx
+++ b/src/app/features/room/ThreadSummary.tsx
@@ -1,0 +1,93 @@
+import React, { MouseEventHandler, useEffect, useState } from 'react';
+import { Icon, Icons, Text } from 'folds';
+import { Room, RoomEvent, Thread, ThreadEvent } from 'matrix-js-sdk';
+import classNames from 'classnames';
+
+import * as css from './ThreadSummary.css';
+import { useMatrixClient } from '../../hooks/useMatrixClient';
+
+/**
+ * Element-style thread summary shown beneath a root message in the main timeline
+ * when that message starts a thread. Shows the thread icon (accented/unread icon
+ * when the current user has unread replies), the reply count, and a preview of
+ * the last reply. Clicking it opens that thread in the ThreadsDrawer panel.
+ */
+type ThreadSummaryProps = {
+  room: Room;
+  thread: Thread;
+  onOpen: () => void;
+};
+
+export function ThreadSummary({ room, thread, onOpen }: ThreadSummaryProps) {
+  const mx = useMatrixClient();
+  // Bumped by SDK events (new reply / update / delete / receipt) so the summary
+  // stays live with the thread and its unread state, mirroring RoomTimeline's
+  // event-driven model rather than polling.
+  const [, setRevision] = useState(0);
+
+  useEffect(() => {
+    const bump = () => setRevision((r) => r + 1);
+    const handleDelete = () => bump();
+    const handleNewReply = () => bump();
+    const handleUpdate = () => bump();
+
+    room.on(ThreadEvent.NewReply as never, handleNewReply as never);
+    room.on(ThreadEvent.Update as unknown as never, handleUpdate as never);
+    room.on(ThreadEvent.Delete as never, handleDelete as never);
+    // read receipts arriving change the unread state for this user
+    room.on(RoomEvent.Receipt as never, bump as never);
+    return () => {
+      room.off(ThreadEvent.NewReply as never, handleNewReply as never);
+      room.off(ThreadEvent.Update as unknown as never, handleUpdate as never);
+      room.off(ThreadEvent.Delete as never, handleDelete as never);
+      room.off(RoomEvent.Receipt as never, bump as never);
+    };
+  }, [room]);
+
+  // The Thread object held by this row is the canonical one from room.getThread();
+  // re-read it on revision so counts/preview reflect the latest data.
+  const liveThread = room.getThread(thread.id) ?? thread;
+  const lastReply = liveThread.lastReply() ?? liveThread.replyToEvent;
+  const replyCount = Math.max(0, liveThread.length);
+  const preview = (() => {
+    if (!lastReply) return undefined;
+    const { body } = lastReply.getContent();
+    if (typeof body !== 'string') return undefined;
+    const trimmed = body.trim();
+    // first few words of the last reply, like Element
+    return trimmed.slice(0, 120);
+  })();
+
+  const myId = mx.getSafeUserId();
+  const iSentLast = !!lastReply && lastReply.getSender() === myId;
+  const hasUnread =
+    !!lastReply && !iSentLast && !!myId && !liveThread.hasUserReadEvent(myId, lastReply.getId());
+
+  if (replyCount <= 0) return null;
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (evt) => {
+    evt.preventDefault();
+    evt.stopPropagation();
+    onOpen();
+  };
+
+  return (
+    <button
+      type="button"
+      className={classNames(css.ThreadSummary, hasUnread && css.ThreadSummaryUnread)}
+      onClick={handleClick}
+      aria-label={hasUnread ? 'Open thread with unread replies' : 'Open thread'}
+    >
+      <Icon
+        size="100"
+        src={hasUnread ? Icons.ThreadUnread : Icons.Thread}
+        style={{ flexShrink: 0 }}
+      />
+      <Text size="T200" priority="300" truncate style={{ flexGrow: 1 }} align="Start">
+        {preview
+          ? `${replyCount} reply${replyCount === 1 ? '' : 's'} · ${preview}`
+          : `${replyCount} reply${replyCount === 1 ? '' : 's'}`}
+      </Text>
+    </button>
+  );
+}

--- a/src/app/features/room/ThreadSummary.tsx
+++ b/src/app/features/room/ThreadSummary.tsx
@@ -4,6 +4,8 @@ import { Room, RoomEvent, Thread, ThreadEvent } from 'matrix-js-sdk';
 
 import * as css from './ThreadSummary.css';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
+import { useThreadUnreadCount } from '../../hooks/useThreadUnreadCount';
+import { UnreadBadge } from '../../components/unread-badge';
 
 /**
  * Element-style thread summary shown beneath a root message in the main timeline
@@ -61,6 +63,9 @@ export function ThreadSummary({ room, thread, onOpen }: ThreadSummaryProps) {
   const iSentLast = !!lastReply && lastReply.getSender() === myId;
   const hasUnread =
     !!lastReply && !iSentLast && !!myId && !liveThread.hasUserReadEvent(myId, lastReply.getId());
+  // Numeric unread count sourced from the room's thread notification map —
+  // the same data the ThreadsDrawer list pill and the left channel list use.
+  const unreadCount = useThreadUnreadCount(room, liveThread);
 
   if (replyCount <= 0) return null;
 
@@ -77,12 +82,13 @@ export function ThreadSummary({ room, thread, onOpen }: ThreadSummaryProps) {
       onClick={handleClick}
       aria-label={hasUnread ? 'Open thread with unread replies' : 'Open thread'}
     >
-      <Icon size="100" src={Icons.Thread} style={{ flexShrink: 0 }} />
+      <Icon size="100" src={hasUnread ? Icons.ThreadUnread : Icons.Thread} style={{ flexShrink: 0 }} />
       <Text size="T200" priority="300" truncate style={{ flexGrow: 1 }} align="Start">
         {preview
           ? `${replyCount} reply${replyCount === 1 ? '' : 's'} · ${preview}`
           : `${replyCount} reply${replyCount === 1 ? '' : 's'}`}
       </Text>
+      {unreadCount > 0 && <UnreadBadge count={unreadCount} />}
     </button>
   );
 }

--- a/src/app/features/room/ThreadSummary.tsx
+++ b/src/app/features/room/ThreadSummary.tsx
@@ -1,7 +1,6 @@
 import React, { MouseEventHandler, useEffect, useState } from 'react';
 import { Icon, Icons, Text } from 'folds';
 import { Room, RoomEvent, Thread, ThreadEvent } from 'matrix-js-sdk';
-import classNames from 'classnames';
 
 import * as css from './ThreadSummary.css';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
@@ -74,15 +73,11 @@ export function ThreadSummary({ room, thread, onOpen }: ThreadSummaryProps) {
   return (
     <button
       type="button"
-      className={classNames(css.ThreadSummary, hasUnread && css.ThreadSummaryUnread)}
+      className={css.ThreadSummary}
       onClick={handleClick}
       aria-label={hasUnread ? 'Open thread with unread replies' : 'Open thread'}
     >
-      <Icon
-        size="100"
-        src={hasUnread ? Icons.ThreadUnread : Icons.Thread}
-        style={{ flexShrink: 0 }}
-      />
+      <Icon size="100" src={Icons.Thread} style={{ flexShrink: 0 }} />
       <Text size="T200" priority="300" truncate style={{ flexGrow: 1 }} align="Start">
         {preview
           ? `${replyCount} reply${replyCount === 1 ? '' : 's'} · ${preview}`

--- a/src/app/features/room/ThreadsDrawer.css.ts
+++ b/src/app/features/room/ThreadsDrawer.css.ts
@@ -4,19 +4,15 @@ import { color, config, toRem } from 'folds';
 export const ThreadsDrawer = style({
   width: toRem(400),
   minWidth: toRem(360),
-  overflow: 'hidden',
-  // Height comes from flexbox: this column is a stretch child of the drawer
-  // row (which itself stretches to the content-area height inside Room), so we
-  // never set a percentage height here — percentage heights resolve to auto when
-  // an ancestor's height is itself flex-stretched rather than definite, which is
-  // what made the reply composer float with thread length. The drawer fills via
-  // flex grow/stretch and `overflow: hidden` clips any overflow.
-  minHeight: 0,
+  // Mirrors MembersDrawer: width only, no overflow/height/minHeight on the
+  // drawer root. Height comes from flexbox stretch (this column is a stretch
+  // child up the chain from #root); adding overflow:hidden or minHeight here
+  // broke that stretch and made the reply composer float with thread length.
 });
 
 // Column wrapper between the drawer and its scroll area. minHeight: 0 lets it
-// shrink below its content (so a tall message list never pushes the reply
-// composer off the bottom); height comes from flex grow, not a percentage.
+// shrink below its content so a tall message list never pushes the reply
+// composer off the bottom. No height/overflow — height comes from flex grow.
 export const ThreadsDrawerBody = style({
   minHeight: 0,
 });

--- a/src/app/features/room/ThreadsDrawer.css.ts
+++ b/src/app/features/room/ThreadsDrawer.css.ts
@@ -4,6 +4,14 @@ import { color, config, toRem } from 'folds';
 export const ThreadsDrawer = style({
   width: toRem(400),
   minWidth: toRem(360),
+  overflow: 'hidden',
+});
+
+// Column wrapper between the drawer and its scroll area. Needs minHeight: 0 so
+// it can shrink below its content instead of pushing the reply composer off the
+// bottom of the window when a thread's messages are tall.
+export const ThreadsDrawerBody = style({
+  minHeight: 0,
 });
 
 // Thin vertical drag handle on the left edge of the drawer.
@@ -38,6 +46,11 @@ export const ThreadsDrawerDetailHeader = style({
 export const ThreadDrawerContentBase = style({
   position: 'relative',
   overflow: 'hidden',
+  // Allow the scroll region to shrink below its content height in the column
+  // so the reply composer stays pinned at the bottom of the window instead of
+  // being pushed off-screen by tall message lists.
+  minHeight: 0,
+  flexGrow: 1,
 });
 
 export const ThreadDrawerContent = style({

--- a/src/app/features/room/ThreadsDrawer.css.ts
+++ b/src/app/features/room/ThreadsDrawer.css.ts
@@ -5,20 +5,19 @@ export const ThreadsDrawer = style({
   width: toRem(400),
   minWidth: toRem(360),
   overflow: 'hidden',
-  // Bound the drawer to the available (viewport) height so a tall message list
-  // never pushes the reply composer off the bottom of the window. The drawer is
-  // a stretched flex child, but this makes the column height explicit.
-  height: '100%',
-  maxHeight: '100%',
+  // Height comes from flexbox: this column is a stretch child of the drawer
+  // row (which itself stretches to the content-area height inside Room), so we
+  // never set a percentage height here — percentage heights resolve to auto when
+  // an ancestor's height is itself flex-stretched rather than definite, which is
+  // what made the reply composer float with thread length. The drawer fills via
+  // flex grow/stretch and `overflow: hidden` clips any overflow.
+  minHeight: 0,
 });
 
-// Column wrapper between the drawer and its scroll area. Needs minHeight: 0 so
-// it can shrink below its content instead of pushing the reply composer off the
-// bottom of the window when a thread's messages are tall, and height: 100% so it
-// (and the fragment it holds) fills the drawer rather than growing with content,
-// which is what made the reply composer float with thread length.
+// Column wrapper between the drawer and its scroll area. minHeight: 0 lets it
+// shrink below its content (so a tall message list never pushes the reply
+// composer off the bottom); height comes from flex grow, not a percentage.
 export const ThreadsDrawerBody = style({
-  height: '100%',
   minHeight: 0,
 });
 

--- a/src/app/features/room/ThreadsDrawer.css.ts
+++ b/src/app/features/room/ThreadsDrawer.css.ts
@@ -47,7 +47,6 @@ export const ThreadsDrawerDetailHeader = style({
   padding: `0 ${config.space.S200} 0 ${config.space.S100}`,
   borderBottomWidth: config.borderWidth.B300,
 });
-
 export const ThreadDrawerContentBase = style({
   position: 'relative',
   overflow: 'hidden',

--- a/src/app/features/room/ThreadsDrawer.css.ts
+++ b/src/app/features/room/ThreadsDrawer.css.ts
@@ -5,6 +5,11 @@ export const ThreadsDrawer = style({
   width: toRem(400),
   minWidth: toRem(360),
   overflow: 'hidden',
+  // Bound the drawer to the available (viewport) height so a tall message list
+  // never pushes the reply composer off the bottom of the window. The drawer is
+  // a stretched flex child, but this makes the column height explicit.
+  height: '100%',
+  maxHeight: '100%',
 });
 
 // Column wrapper between the drawer and its scroll area. Needs minHeight: 0 so

--- a/src/app/features/room/ThreadsDrawer.css.ts
+++ b/src/app/features/room/ThreadsDrawer.css.ts
@@ -1,8 +1,26 @@
 import { style } from '@vanilla-extract/css';
-import { config, toRem } from 'folds';
+import { color, config, toRem } from 'folds';
 
 export const ThreadsDrawer = style({
-  width: toRem(320),
+  width: toRem(400),
+  minWidth: toRem(360),
+});
+
+// Thin vertical drag handle on the left edge of the drawer.
+export const ThreadsDrawerResizer = style({
+  flexShrink: 0,
+  width: toRem(6),
+  cursor: 'col-resize',
+  background: 'transparent',
+  transition: 'background 0.15s ease',
+  ':hover': {
+    background: color.Primary.ContainerLine,
+  },
+  selectors: {
+    '&:active': {
+      background: color.Primary.MainLine,
+    },
+  },
 });
 
 export const ThreadsDrawerHeader = style({

--- a/src/app/features/room/ThreadsDrawer.css.ts
+++ b/src/app/features/room/ThreadsDrawer.css.ts
@@ -1,0 +1,27 @@
+import { style } from '@vanilla-extract/css';
+import { config, toRem } from 'folds';
+
+export const ThreadsDrawer = style({
+  width: toRem(320),
+});
+
+export const ThreadsDrawerHeader = style({
+  flexShrink: 0,
+  padding: `0 ${config.space.S200} 0 ${config.space.S300}`,
+  borderBottomWidth: config.borderWidth.B300,
+});
+
+export const ThreadsDrawerDetailHeader = style({
+  flexShrink: 0,
+  padding: `0 ${config.space.S200} 0 ${config.space.S100}`,
+  borderBottomWidth: config.borderWidth.B300,
+});
+
+export const ThreadDrawerContentBase = style({
+  position: 'relative',
+  overflow: 'hidden',
+});
+
+export const ThreadDrawerContent = style({
+  padding: `${config.space.S200} 0`,
+});

--- a/src/app/features/room/ThreadsDrawer.css.ts
+++ b/src/app/features/room/ThreadsDrawer.css.ts
@@ -14,8 +14,11 @@ export const ThreadsDrawer = style({
 
 // Column wrapper between the drawer and its scroll area. Needs minHeight: 0 so
 // it can shrink below its content instead of pushing the reply composer off the
-// bottom of the window when a thread's messages are tall.
+// bottom of the window when a thread's messages are tall, and height: 100% so it
+// (and the fragment it holds) fills the drawer rather than growing with content,
+// which is what made the reply composer float with thread length.
 export const ThreadsDrawerBody = style({
+  height: '100%',
   minHeight: 0,
 });
 

--- a/src/app/features/room/ThreadsDrawer.css.ts
+++ b/src/app/features/room/ThreadsDrawer.css.ts
@@ -10,13 +10,6 @@ export const ThreadsDrawer = style({
   // broke that stretch and made the reply composer float with thread length.
 });
 
-// Column wrapper between the drawer and its scroll area. minHeight: 0 lets it
-// shrink below its content so a tall message list never pushes the reply
-// composer off the bottom. No height/overflow — height comes from flex grow.
-export const ThreadsDrawerBody = style({
-  minHeight: 0,
-});
-
 // Thin vertical drag handle on the left edge of the drawer.
 export const ThreadsDrawerResizer = style({
   flexShrink: 0,

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -505,7 +505,7 @@ function ThreadMenu({
                   radii="300"
                 >
                   <Text style={{ flexGrow: 1 }} as="span" size="T300" truncate>
-                    Copy link to thread
+                    Copy Link
                   </Text>
                 </MenuItem>
               </Box>
@@ -731,7 +731,7 @@ export function ThreadsDrawer({ room }: ThreadsDrawerProps) {
   }, [threads, selectedThread, room]);
 
   return (
-    <Box shrink="No" direction="Row">
+    <Box shrink="No" direction="Row" style={{ height: '100%' }}>
       <div
         className={css.ThreadsDrawerResizer}
         onPointerDown={startResize}

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -379,7 +379,8 @@ function ThreadDetail({
 }) {
   const { rootEvent } = thread;
   const senderId = rootEvent?.getSender() ?? '';
-  const title = senderId ? getSenderName(room, senderId) : 'Thread';
+  const title =
+    getThreadPreview(rootEvent) || (senderId ? getSenderName(room, senderId) : 'Thread');
 
   return (
     <>
@@ -568,7 +569,7 @@ export function ThreadsDrawer({ room }: ThreadsDrawerProps) {
         shrink="No"
         direction="Column"
       >
-        <Box grow="Yes" direction="Column">
+        <Box grow="Yes" direction="Column" className={css.ThreadsDrawerBody}>
           {selectedThread ? (
             <ThreadDetail
               room={room}

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -8,12 +8,13 @@ import {
   Icons,
   MenuItem,
   Scroll,
+  Spinner,
   Text,
   Tooltip,
   TooltipProvider,
   config,
 } from 'folds';
-import { MatrixEvent, Room, Thread, ThreadEvent } from 'matrix-js-sdk';
+import { MatrixEvent, Room, RoomEvent, Thread, ThreadEvent } from 'matrix-js-sdk';
 import classNames from 'classnames';
 import { Opts as LinkifyOpts } from 'linkifyjs';
 import { HTMLReactParserOptions } from 'html-react-parser';
@@ -198,12 +199,90 @@ function ThreadMessages({ room, thread }: { room: Room; thread: Thread }) {
     [mx, room, linkifyOpts, spoilerClickHandler, mentionClickHandler, useAuthentication]
   );
 
+  // Authentic thread data model: the room re-emits the thread timeline set's
+  // RoomEvent.Timeline / TimelineRefresh / Redaction (and thread events). React
+  // to those SDK events to re-render — this is the same event-driven model
+  // RoomTimeline uses, not polling. A thread created from the server thread list
+  // starts with few/no events loaded, so backfill by paginating its timeline.
+  const [revision, setRevision] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // Only re-render when the event actually belongs to this thread's timeline
+    // set (the room re-emits it with the event as first arg).
+    const inThread = (mEvent?: MatrixEvent | null) =>
+      !!thread.timelineSet &&
+      !!mEvent &&
+      (!!mEvent.getThread() ||
+        thread.timelineSet
+          .getLiveTimeline()
+          .getEvents()
+          .some((e) => e.getId() === mEvent.getId()));
+    const onTimeline: (
+      mEvent: MatrixEvent,
+      eventRoom?: Room | null,
+      toStart?: boolean,
+      removed?: boolean,
+      data?: object
+    ) => void = (mEvent) => {
+      if (inThread(mEvent)) setRevision((r) => r + 1);
+    };
+    const onRefresh: (r: { roomId: string }) => void = ({ roomId }) => {
+      if (roomId === room.roomId) setRevision((r) => r + 1);
+    };
+    const onRedaction: (mEvent: MatrixEvent, eventRoom?: Room | null) => void = (mEvent) => {
+      if (inThread(mEvent)) setRevision((r) => r + 1);
+    };
+
+    room.on(RoomEvent.Timeline as never, onTimeline as never);
+    room.on(RoomEvent.TimelineRefresh as never, onRefresh as never);
+    room.on(RoomEvent.Redaction as never, onRedaction as never);
+    return () => {
+      room.off(RoomEvent.Timeline as never, onTimeline as never);
+      room.off(RoomEvent.TimelineRefresh as never, onRefresh as never);
+      room.off(RoomEvent.Redaction as never, onRedaction as never);
+    };
+  }, [room, thread]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const timeline = thread.timelineSet.getLiveTimeline();
+    const alreadyLoaded = timeline.getEvents().length > 0;
+    const backfill = async () => {
+      setLoading(true);
+      try {
+        // Keep pulling older events until the thread's history is exhausted.
+        // Each paginate call advances the thread timeline token, so it must run
+        // sequentially (hence the awaited loop).
+        // eslint-disable-next-line no-constant-condition
+        while (!cancelled) {
+          // eslint-disable-next-line no-await-in-loop
+          const hasMore = await mx.paginateEventTimeline(timeline, { backwards: true, limit: 50 });
+          if (!hasMore) break;
+        }
+      } catch {
+        // ignore pagination errors (e.g. decrypt in progress)
+      } finally {
+        if (!cancelled) {
+          setRevision((r) => r + 1);
+          setLoading(false);
+        }
+      }
+    };
+    if (!alreadyLoaded) backfill();
+    else setLoading(false);
+    return () => {
+      cancelled = true;
+    };
+  }, [mx, thread]);
+
   const events = useMemo(() => {
     const live: MatrixEvent[] = thread.timelineSet.getLiveTimeline().getEvents();
     const root = thread.rootEvent;
     const withRoot = root ? [root, ...live] : live;
     return withRoot.filter((m: MatrixEvent) => m.getType() === MessageEvent.RoomMessage);
-  }, [thread]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [thread, revision]);
 
   const onUserClick: MouseEventHandler<HTMLButtonElement> = useCallback((evt) => {
     evt.preventDefault();
@@ -213,6 +292,19 @@ function ThreadMessages({ room, thread }: { room: Room; thread: Thread }) {
     evt.preventDefault();
   }, []);
   const onReactionToggle = useCallback(() => undefined, []);
+
+  if (loading) {
+    return (
+      <Box
+        direction="Column"
+        alignItems="Center"
+        justifyContent="Center"
+        style={{ padding: config.space.S400 }}
+      >
+        <Spinner variant="Secondary" size="400" />
+      </Box>
+    );
+  }
 
   if (events.length === 0) {
     return (
@@ -340,15 +432,21 @@ export function ThreadsDrawer({ room }: ThreadsDrawerProps) {
     room.on(ThreadEvent.New as never, handleNewReply as never);
     room.on(ThreadEvent.Delete as never, handleDelete as never);
 
-    // Bootstrap the full server-side thread list for this room if the SDK
-    // supports it. Populates room.getThreads() with threads that may not be
-    // present in the locally-loaded timeline window yet.
+    // Bootstrap the full server-side thread list for this room. room.getThreads()
+    // only reflects threads already in the locally-loaded timeline; the SDK's
+    // fetchRoomThreads() (enabled by threadSupport) pulls the complete /threads
+    // list, registers every root into room.threads (firing ThreadEvent.New), and
+    // sets threadsReady. We keep a local copy and refresh from room.getThreads().
+    let cancelled = false;
     room
-      .createThreadsTimelineSets()
-      .then(update)
-      .catch(() => undefined);
+      .fetchRoomThreads()
+      .catch(() => undefined)
+      .finally(() => {
+        if (!cancelled) update();
+      });
 
     return () => {
+      cancelled = true;
       room.off(ThreadEvent.NewReply as never, handleNewReply as never);
       room.off(ThreadEvent.Update as unknown as never, handleUpdate as never);
       room.off(ThreadEvent.New as never, handleNewReply as never);

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -98,9 +98,8 @@ function ThreadListItem({
 }) {
   const unreadCount = useThreadUnreadCount(room, thread);
   const { rootEvent } = thread;
-  const senderId = rootEvent?.getSender() ?? '';
-  const sender = senderId ? getSenderName(room, senderId) : 'Unknown';
   const preview = getThreadPreview(rootEvent);
+  const replyCount = Math.max(0, thread.length);
 
   return (
     <MenuItem
@@ -115,12 +114,12 @@ function ThreadListItem({
       }
     >
       <Box direction="Column" gap="100" grow="Yes">
+        <Text size="B300" truncate>
+          {preview || 'Thread'}
+        </Text>
         <Box alignItems="Center" gap="100">
-          <Text size="B300" truncate>
-            {sender}
-          </Text>
-          <Text size="B300" priority="300" truncate>
-            {preview}
+          <Text size="T200" priority="300">
+            {replyCount} reply{replyCount === 1 ? '' : 's'}
           </Text>
           <Box shrink="No" alignItems="Center" style={{ marginLeft: 'auto' }}>
             {unreadCount > 0 && <UnreadBadge count={unreadCount} />}

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -7,7 +7,10 @@ import {
   Icon,
   IconButton,
   Icons,
+  Menu,
   MenuItem,
+  PopOut,
+  RectCords,
   Scroll,
   Spinner,
   Text,
@@ -18,8 +21,15 @@ import {
 } from 'folds';
 import { MatrixEvent, Room, RoomEvent, Thread, ThreadEvent } from 'matrix-js-sdk';
 import classNames from 'classnames';
+import FocusTrap from 'focus-trap-react';
 import { Opts as LinkifyOpts } from 'linkifyjs';
 import { HTMLReactParserOptions } from 'html-react-parser';
+
+import { useRoomNavigate } from '../../hooks/useRoomNavigate';
+import { getMatrixToRoomEvent } from '../../plugins/matrix-to';
+import { getViaServers } from '../../plugins/via-servers';
+import { copyToClipboard } from '../../utils/dom';
+import { stopPropagation } from '../../utils/keyboard';
 
 import * as css from './ThreadsDrawer.css';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
@@ -378,6 +388,88 @@ function ThreadMessages({ room, thread }: { room: Room; thread: Thread }) {
   );
 }
 
+function ThreadMenu({
+  room,
+  thread,
+  onViewInThread,
+}: {
+  room: Room;
+  thread: Thread;
+  onViewInThread: () => void;
+}) {
+  const [menuAnchor, setMenuAnchor] = useState<RectCords>();
+  const rootEventId = thread.rootEvent?.getId();
+
+  const handleOpenMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {
+    setMenuAnchor(evt.currentTarget.getBoundingClientRect());
+  };
+
+  const handleViewInThread = () => {
+    setMenuAnchor(undefined);
+    onViewInThread();
+  };
+
+  const handleCopyLink = () => {
+    if (!rootEventId) return;
+    copyToClipboard(getMatrixToRoomEvent(room.roomId, rootEventId, getViaServers(room)));
+    setMenuAnchor(undefined);
+  };
+
+  return (
+    <>
+      <IconButton
+        variant="Background"
+        aria-pressed={!!menuAnchor}
+        onClick={handleOpenMenu}
+        aria-label="Thread options"
+      >
+        <Icon src={Icons.VerticalDots} />
+      </IconButton>
+      <PopOut
+        anchor={menuAnchor}
+        position="Bottom"
+        align="End"
+        content={
+          <FocusTrap
+            focusTrapOptions={{
+              initialFocus: false,
+              clickOutsideDeactivates: true,
+              onDeactivate: () => setMenuAnchor(undefined),
+              returnFocusOnDeactivate: false,
+              isKeyForward: (evt: KeyboardEvent) => evt.key === 'ArrowDown',
+              isKeyBackward: (evt: KeyboardEvent) => evt.key === 'ArrowUp',
+              escapeDeactivates: stopPropagation,
+            }}
+          >
+            <Menu>
+              <MenuItem
+                size="300"
+                radii="300"
+                after={<Icon size="100" src={Icons.External} />}
+                onClick={handleViewInThread}
+              >
+                <Text size="T300" truncate>
+                  View in Thread
+                </Text>
+              </MenuItem>
+              <MenuItem
+                size="300"
+                radii="300"
+                after={<Icon size="100" src={Icons.Link} />}
+                onClick={handleCopyLink}
+              >
+                <Text size="T300" truncate>
+                  Copy link to thread
+                </Text>
+              </MenuItem>
+            </Menu>
+          </FocusTrap>
+        }
+      />
+    </>
+  );
+}
+
 function ThreadDetail({
   room,
   thread,
@@ -393,6 +485,16 @@ function ThreadDetail({
   const senderId = rootEvent?.getSender() ?? '';
   const title =
     getThreadPreview(rootEvent) || (senderId ? getSenderName(room, senderId) : 'Thread');
+  const { navigateRoom } = useRoomNavigate();
+
+  const handleViewInThread = () => {
+    // Navigate to the room with the root (thread-starting) event focused so the
+    // main timeline scrolls to and highlights the parent message, then close
+    // the panel so the main timeline is visible.
+    const rootEventId = thread.rootEvent?.getId();
+    if (rootEventId) navigateRoom(room.roomId, rootEventId);
+    onClose();
+  };
 
   return (
     <>
@@ -418,6 +520,7 @@ function ThreadDetail({
             {title}
           </Text>
         </Box>
+        <ThreadMenu room={room} thread={thread} onViewInThread={handleViewInThread} />
         <TooltipProvider
           position="Bottom"
           align="End"

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -1,4 +1,11 @@
-import React, { MouseEventHandler, useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  MouseEventHandler,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import {
   Avatar,
@@ -31,7 +38,7 @@ import { useThreadUnreadCount } from '../../hooks/useThreadUnreadCount';
 import { UnreadBadge } from '../../components/unread-badge';
 import { getMatrixToRoomEvent } from '../../plugins/matrix-to';
 import { getViaServers } from '../../plugins/via-servers';
-import { copyToClipboard } from '../../utils/dom';
+import { copyToClipboard, scrollToBottom } from '../../utils/dom';
 import { stopPropagation } from '../../utils/keyboard';
 
 import * as css from './ThreadsDrawer.css';
@@ -180,7 +187,15 @@ function ThreadList({
   );
 }
 
-function ThreadMessages({ room, thread }: { room: Room; thread: Thread }) {
+function ThreadMessages({
+  room,
+  thread,
+  onEventsCount,
+}: {
+  room: Room;
+  thread: Thread;
+  onEventsCount?: (count: number) => void;
+}) {
   const mx = useMatrixClient();
   const [hideActivity] = useSetting(settingsAtom, 'hideActivity');
   const [messageLayout] = useSetting(settingsAtom, 'messageLayout');
@@ -326,6 +341,13 @@ function ThreadMessages({ room, thread }: { room: Room; thread: Thread }) {
     return withRoot.filter((m: MatrixEvent) => m.getType() === MessageEvent.RoomMessage);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [thread, revision]);
+
+  // Notify the parent (ThreadDetail) whenever the rendered event count changes
+  // so it can scroll the thread view to the bottom on a new reply (local or
+  // remote echo) — mirroring RoomTimeline's auto-scroll-to-latest behavior.
+  useEffect(() => {
+    onEventsCount?.(events.length);
+  }, [events.length, onEventsCount]);
 
   const onUserClick: MouseEventHandler<HTMLButtonElement> = useCallback((evt) => {
     evt.preventDefault();
@@ -545,6 +567,20 @@ function ThreadDetail({
     if (lastEvent) mx.sendReadReceipt(lastEvent);
   }, [mx, thread]);
 
+  // Auto-scroll the thread message view to the bottom whenever a new reply
+  // arrives (the event count grows) so the viewer sees their freshly sent
+  // reply and incoming replies without manual scrolling — mirroring the main
+  // timeline's scroll-to-latest behavior.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const prevEventCountRef = useRef<number>(-1);
+  const handleEventsCount = useCallback((count: number) => {
+    if (count > prevEventCountRef.current) {
+      const el = scrollRef.current;
+      if (el) scrollToBottom(el, 'auto');
+    }
+    prevEventCountRef.current = count;
+  }, []);
+
   const handleViewInThread = () => {
     // Navigate to the room with the root (thread-starting) event focused so the
     // main timeline scrolls to and highlights the parent message, then close
@@ -597,9 +633,9 @@ function ThreadDetail({
         </TooltipProvider>
       </Header>
       <Box className={css.ThreadDrawerContentBase} grow="Yes">
-        <Scroll variant="Background" size="300" visibility="Always" hideTrack={false}>
+        <Scroll ref={scrollRef} variant="Background" size="300" visibility="Always" hideTrack={false}>
           <Box className={css.ThreadDrawerContent} direction="Column" gap="100">
-            <ThreadMessages room={room} thread={thread} />
+            <ThreadMessages room={room} thread={thread} onEventsCount={handleEventsCount} />
           </Box>
         </Scroll>
       </Box>

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -778,11 +778,25 @@ export function ThreadsDrawer({ room }: ThreadsDrawerProps) {
     const handleNewReply = () => update();
     const handleUpdate = () => update();
     const handleDelete = () => update();
+    // Same live-new-thread fix as RoomTimeline: handleRemoteEcho() skips thread
+    // creation for our own thread replies, so ThreadEvent.New never fires and
+    // the list would miss the new thread until a reload. Create the Thread
+    // manually on LocalEchoUpdated when it doesn't exist yet.
+    const handleLocalEchoUpdated = (mEvent: MatrixEvent) => {
+      const rootId = mEvent.threadRootId;
+      if (rootId && !room.getThread(rootId)) {
+        const rootEvent = room.findEventById(rootId);
+        if (rootEvent) {
+          room.processThreadRoots([rootEvent], false);
+        }
+      }
+    };
 
     room.on(ThreadEvent.NewReply as never, handleNewReply as never);
     room.on(ThreadEvent.Update as unknown as never, handleUpdate as never);
     room.on(ThreadEvent.New as never, handleNewReply as never);
     room.on(ThreadEvent.Delete as never, handleDelete as never);
+    room.on(RoomEvent.LocalEchoUpdated as never, handleLocalEchoUpdated as never);
 
     // Bootstrap the full server-side thread list for this room. room.getThreads()
     // only reflects threads already in the locally-loaded timeline; the SDK's
@@ -803,6 +817,7 @@ export function ThreadsDrawer({ room }: ThreadsDrawerProps) {
       room.off(ThreadEvent.Update as unknown as never, handleUpdate as never);
       room.off(ThreadEvent.New as never, handleNewReply as never);
       room.off(ThreadEvent.Delete as never, handleDelete as never);
+      room.off(RoomEvent.LocalEchoUpdated as never, handleLocalEchoUpdated as never);
     };
   }, [room]);
 

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -1,4 +1,5 @@
 import React, { MouseEventHandler, useCallback, useEffect, useMemo, useState } from 'react';
+import { useAtomValue, useSetAtom } from 'jotai';
 import {
   Avatar,
   Box,
@@ -13,6 +14,7 @@ import {
   Tooltip,
   TooltipProvider,
   config,
+  toRem,
 } from 'folds';
 import { MatrixEvent, Room, RoomEvent, Thread, ThreadEvent } from 'matrix-js-sdk';
 import classNames from 'classnames';
@@ -23,6 +25,7 @@ import * as css from './ThreadsDrawer.css';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import { useSetting, useSetSetting } from '../../state/hooks/settings';
 import { settingsAtom, MessageLayout } from '../../state/settings';
+import { selectedThreadAtom } from '../../state/room/threadSelection';
 import {
   factoryRenderLinkifyWithMention,
   getReactCustomHtmlParser,
@@ -44,6 +47,7 @@ import { usePowerLevelsContext } from '../../hooks/usePowerLevels';
 import { useTheme } from '../../hooks/useTheme';
 import { RenderMessageContent } from '../../components/RenderMessageContent';
 import { Message } from './message';
+import ThreadReplyInput from './ThreadReplyInput';
 import { GetContentCallback, MessageEvent } from '../../../types/matrix/room';
 import { ContainerColor } from '../../styles/ContainerColor.css';
 
@@ -366,10 +370,12 @@ function ThreadDetail({
   room,
   thread,
   onBack,
+  onClose,
 }: {
   room: Room;
   thread: Thread;
   onBack: () => void;
+  onClose: () => void;
 }) {
   const { rootEvent } = thread;
   const senderId = rootEvent?.getSender() ?? '';
@@ -399,6 +405,22 @@ function ThreadDetail({
             {title}
           </Text>
         </Box>
+        <TooltipProvider
+          position="Bottom"
+          align="End"
+          offset={4}
+          tooltip={
+            <Tooltip>
+              <Text>Close</Text>
+            </Tooltip>
+          }
+        >
+          {(triggerRef) => (
+            <IconButton ref={triggerRef} variant="Background" onClick={onClose}>
+              <Icon src={Icons.Cross} />
+            </IconButton>
+          )}
+        </TooltipProvider>
       </Box>
       <Box className={css.ThreadDrawerContentBase} grow="Yes">
         <Scroll variant="Background" size="300" visibility="Always" hideTrack={false}>
@@ -407,6 +429,7 @@ function ThreadDetail({
           </Box>
         </Scroll>
       </Box>
+      <ThreadReplyInput room={room} thread={thread} />
     </>
   );
 }
@@ -415,10 +438,79 @@ type ThreadsDrawerProps = {
   room: Room;
 };
 
+const DEFAULT_THREAD_DRAWER_WIDTH = 400;
+const MIN_THREAD_DRAWER_WIDTH = 320;
+const MAX_THREAD_DRAWER_WIDTH = 640;
+const THREAD_DRAWER_WIDTH_KEY = 'cinny.threadsDrawerWidth';
+
+function readStoredWidth(): number {
+  try {
+    const raw = Number.parseInt(localStorage.getItem(THREAD_DRAWER_WIDTH_KEY) ?? '', 10);
+    if (Number.isNaN(raw)) return DEFAULT_THREAD_DRAWER_WIDTH;
+    return Math.min(MAX_THREAD_DRAWER_WIDTH, Math.max(MIN_THREAD_DRAWER_WIDTH, raw));
+  } catch {
+    return DEFAULT_THREAD_DRAWER_WIDTH;
+  }
+}
+
 export function ThreadsDrawer({ room }: ThreadsDrawerProps) {
   const setThreadsDrawer = useSetSetting(settingsAtom, 'threadsDrawer');
+  const bootSelection = useAtomValue(selectedThreadAtom);
+  const setBootSelection = useSetAtom(selectedThreadAtom);
   const [selectedThread, setSelectedThread] = useState<Thread>();
   const [threads, setThreads] = useState<Thread[]>(() => room.getThreads());
+  const [drawerWidth, setDrawerWidth] = useState<number>(readStoredWidth);
+  const [isResizing, setIsResizing] = useState(false);
+
+  // If the timeline's thread summary opened a specific thread, select it here
+  // (and clear the request so a later drawer-open starts at the list).
+  useEffect(() => {
+    if (bootSelection?.roomId === room.roomId && bootSelection.threadId) {
+      const thread = room.getThread(bootSelection.threadId);
+      if (thread) {
+        setSelectedThread(thread);
+        setBootSelection(undefined);
+      }
+    }
+  }, [bootSelection, room, setBootSelection]);
+
+  // Persist the resized width so it survives reloads.
+  useEffect(() => {
+    try {
+      localStorage.setItem(THREAD_DRAWER_WIDTH_KEY, String(drawerWidth));
+    } catch {
+      // ignore storage failures (private mode / quota)
+    }
+  }, [drawerWidth]);
+
+  // Pointer-based resizing: dragging changes the width until the pointer is
+  // released. Listeners attach on the window only while resizing is active.
+  const startResize = useCallback((evt: React.PointerEvent<HTMLElement>) => {
+    evt.preventDefault();
+    evt.stopPropagation();
+    setIsResizing(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isResizing) return undefined;
+    const onMove = (evt: PointerEvent) => {
+      // The drawer's right edge is pinned at the viewport right; dragging left
+      // grows the drawer, dragging right shrinks it.
+      const width = window.innerWidth - evt.clientX;
+      setDrawerWidth(Math.min(MAX_THREAD_DRAWER_WIDTH, Math.max(MIN_THREAD_DRAWER_WIDTH, width)));
+    };
+    const onUp = () => {
+      setIsResizing(false);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
+    };
+  }, [isResizing]);
 
   useEffect(() => {
     const update = () => setThreads(room.getThreads());
@@ -464,26 +556,41 @@ export function ThreadsDrawer({ room }: ThreadsDrawerProps) {
   }, [threads, selectedThread, room]);
 
   return (
-    <Box
-      className={classNames(css.ThreadsDrawer, ContainerColor({ variant: 'Background' }))}
-      shrink="No"
-      direction="Column"
-    >
-      <Box grow="Yes" direction="Column">
-        {selectedThread ? (
-          <ThreadDetail
-            room={room}
-            thread={selectedThread}
-            onBack={() => setSelectedThread(undefined)}
-          />
-        ) : (
-          <ThreadList
-            room={room}
-            threads={threads}
-            onSelect={setSelectedThread}
-            onClose={() => setThreadsDrawer(false)}
-          />
-        )}
+    <Box shrink="No" direction="Row">
+      <div
+        className={css.ThreadsDrawerResizer}
+        onPointerDown={startResize}
+        style={{ cursor: isResizing ? 'col-resize' : undefined }}
+      />
+      <Box
+        className={classNames(css.ThreadsDrawer, ContainerColor({ variant: 'Background' }))}
+        style={{ width: toRem(drawerWidth) }}
+        shrink="No"
+        direction="Column"
+      >
+        <Box grow="Yes" direction="Column">
+          {selectedThread ? (
+            <ThreadDetail
+              room={room}
+              thread={selectedThread}
+              onClose={() => setThreadsDrawer(false)}
+              onBack={() => {
+                setSelectedThread(undefined);
+                setBootSelection(undefined);
+              }}
+            />
+          ) : (
+            <ThreadList
+              room={room}
+              threads={threads}
+              onSelect={(thread) => {
+                setSelectedThread(thread);
+                setBootSelection({ roomId: room.roomId, threadId: thread.id });
+              }}
+              onClose={() => setThreadsDrawer(false)}
+            />
+          )}
+        </Box>
       </Box>
     </Box>
   );

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -294,13 +294,15 @@ function ThreadMessages({
   useEffect(() => {
     let cancelled = false;
     const timeline = thread.timelineSet.getLiveTimeline();
-    const alreadyLoaded = timeline.getEvents().length > 0;
     const backfill = async () => {
       setLoading(true);
       try {
         // Keep pulling older events until the thread's history is exhausted.
         // Each paginate call advances the thread timeline token, so it must run
-        // sequentially (hence the awaited loop).
+        // sequentially (hence the awaited loop). Always run to exhaustion even
+        // if some events are already loaded from sync — a thread with 73
+        // replies may only have its 8 most-recent events locally, and skipping
+        // backfill here would leave the rest unrendered.
         // eslint-disable-next-line no-constant-condition
         while (!cancelled) {
           // eslint-disable-next-line no-await-in-loop
@@ -316,8 +318,7 @@ function ThreadMessages({
         }
       }
     };
-    if (!alreadyLoaded) backfill();
-    else setLoading(false);
+    backfill();
     return () => {
       cancelled = true;
     };
@@ -777,31 +778,30 @@ export function ThreadsDrawer({ room }: ThreadsDrawerProps) {
         className={classNames(css.ThreadsDrawer, ContainerColor({ variant: 'Background' }))}
         style={{ width: toRem(drawerWidth) }}
         shrink="No"
+        grow="Yes"
         direction="Column"
       >
-        <Box grow="Yes" direction="Column" className={css.ThreadsDrawerBody}>
-          {selectedThread ? (
-            <ThreadDetail
-              room={room}
-              thread={selectedThread}
-              onClose={() => setThreadsDrawer(false)}
-              onBack={() => {
-                setSelectedThread(undefined);
-                setBootSelection(undefined);
-              }}
-            />
-          ) : (
-            <ThreadList
-              room={room}
-              threads={threads}
-              onSelect={(thread) => {
-                setSelectedThread(thread);
-                setBootSelection({ roomId: room.roomId, threadId: thread.id });
-              }}
-              onClose={() => setThreadsDrawer(false)}
-            />
-          )}
-        </Box>
+        {selectedThread ? (
+          <ThreadDetail
+            room={room}
+            thread={selectedThread}
+            onClose={() => setThreadsDrawer(false)}
+            onBack={() => {
+              setSelectedThread(undefined);
+              setBootSelection(undefined);
+            }}
+          />
+        ) : (
+          <ThreadList
+            room={room}
+            threads={threads}
+            onSelect={(thread) => {
+              setSelectedThread(thread);
+              setBootSelection({ roomId: room.roomId, threadId: thread.id });
+            }}
+            onClose={() => setThreadsDrawer(false)}
+          />
+        )}
       </Box>
     </Box>
   );

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -48,6 +48,7 @@ import { useTheme } from '../../hooks/useTheme';
 import { RenderMessageContent } from '../../components/RenderMessageContent';
 import { Message } from './message';
 import ThreadReplyInput from './ThreadReplyInput';
+import { RoomViewFollowingPlaceholder } from './RoomViewFollowing';
 import { GetContentCallback, MessageEvent } from '../../../types/matrix/room';
 import { ContainerColor } from '../../styles/ContainerColor.css';
 
@@ -283,7 +284,18 @@ function ThreadMessages({ room, thread }: { room: Room; thread: Thread }) {
   const events = useMemo(() => {
     const live: MatrixEvent[] = thread.timelineSet.getLiveTimeline().getEvents();
     const root = thread.rootEvent;
-    const withRoot = root ? [root, ...live] : live;
+    const rootId = root?.getId();
+    // Some thread timeline sets already contain the root event (e.g. after
+    // backfill via the /messages thread filter) while others do not. Prepend
+    // the root once, but only when it is not already present, to avoid the
+    // root message rendering twice.
+    const alreadyHasRoot = !!rootId && live.some((m) => m.getId() === rootId);
+    let withRoot: MatrixEvent[];
+    if (alreadyHasRoot || !root) {
+      withRoot = live;
+    } else {
+      withRoot = [root, ...live];
+    }
     return withRoot.filter((m: MatrixEvent) => m.getType() === MessageEvent.RoomMessage);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [thread, revision]);
@@ -431,6 +443,7 @@ function ThreadDetail({
         </Scroll>
       </Box>
       <ThreadReplyInput room={room} thread={thread} />
+      <RoomViewFollowingPlaceholder />
     </>
   );
 }

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -1,0 +1,392 @@
+import React, { MouseEventHandler, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Avatar,
+  Box,
+  Header,
+  Icon,
+  IconButton,
+  Icons,
+  MenuItem,
+  Scroll,
+  Text,
+  Tooltip,
+  TooltipProvider,
+  config,
+} from 'folds';
+import { MatrixEvent, Room, Thread, ThreadEvent } from 'matrix-js-sdk';
+import classNames from 'classnames';
+import { Opts as LinkifyOpts } from 'linkifyjs';
+import { HTMLReactParserOptions } from 'html-react-parser';
+
+import * as css from './ThreadsDrawer.css';
+import { useMatrixClient } from '../../hooks/useMatrixClient';
+import { useSetting, useSetSetting } from '../../state/hooks/settings';
+import { settingsAtom, MessageLayout } from '../../state/settings';
+import {
+  factoryRenderLinkifyWithMention,
+  getReactCustomHtmlParser,
+  LINKIFY_OPTS,
+  makeMentionCustomProps,
+  renderMatrixMention,
+} from '../../plugins/react-custom-html-parser';
+import { getMemberDisplayName } from '../../utils/room';
+import { getMxIdLocalPart } from '../../utils/matrix';
+import { useMediaAuthentication } from '../../hooks/useMediaAuthentication';
+import { useMentionClickHandler } from '../../hooks/useMentionClickHandler';
+import { useSpoilerClickHandler } from '../../hooks/useSpoilerClickHandler';
+import { useIsDirectRoom } from '../../hooks/useRoom';
+import { useRoomCreators } from '../../hooks/useRoomCreators';
+import { useAccessiblePowerTagColors, useGetMemberPowerTag } from '../../hooks/useMemberPowerTag';
+import { useRoomCreatorsTag } from '../../hooks/useRoomCreatorsTag';
+import { usePowerLevelTags } from '../../hooks/usePowerLevelTags';
+import { usePowerLevelsContext } from '../../hooks/usePowerLevels';
+import { useTheme } from '../../hooks/useTheme';
+import { RenderMessageContent } from '../../components/RenderMessageContent';
+import { Message } from './message';
+import { GetContentCallback, MessageEvent } from '../../../types/matrix/room';
+import { ContainerColor } from '../../styles/ContainerColor.css';
+
+function getSenderName(room: Room, userId: string): string {
+  return getMemberDisplayName(room, userId) ?? getMxIdLocalPart(userId) ?? userId;
+}
+
+function getThreadPreview(rootEvent: MatrixEvent | undefined): string {
+  const body = rootEvent?.getContent().body;
+  if (typeof body !== 'string') return '';
+  return body;
+}
+
+function ThreadList({
+  room,
+  threads,
+  onSelect,
+  onClose,
+}: {
+  room: Room;
+  threads: Thread[];
+  onSelect: (thread: Thread) => void;
+  onClose: () => void;
+}) {
+  return (
+    <>
+      <Header className={css.ThreadsDrawerHeader} variant="Background" size="600">
+        <Box grow="Yes" alignItems="Center" gap="200">
+          <Text size="H5" truncate>
+            {`${threads.length} Thread${threads.length === 1 ? '' : 's'}`}
+          </Text>
+        </Box>
+        <Box shrink="No" alignItems="Center">
+          <TooltipProvider
+            position="Bottom"
+            align="End"
+            offset={4}
+            tooltip={
+              <Tooltip>
+                <Text>Close</Text>
+              </Tooltip>
+            }
+          >
+            {(triggerRef) => (
+              <IconButton ref={triggerRef} variant="Background" onClick={onClose}>
+                <Icon src={Icons.Cross} />
+              </IconButton>
+            )}
+          </TooltipProvider>
+        </Box>
+      </Header>
+      <Box className={css.ThreadDrawerContentBase} grow="Yes">
+        <Scroll variant="Background" size="300" visibility="Hover" hideTrack>
+          <Box className={css.ThreadDrawerContent} direction="Column" gap="100">
+            {threads.length === 0 && (
+              <Text style={{ padding: config.space.S300 }} align="Center">
+                No Threads
+              </Text>
+            )}
+            {threads.map((thread) => {
+              const { rootEvent } = thread;
+              const senderId = rootEvent?.getSender() ?? '';
+              const sender = senderId ? getSenderName(room, senderId) : 'Unknown';
+              const preview = getThreadPreview(rootEvent);
+              const replyCount = Math.max(0, thread.length);
+
+              return (
+                <MenuItem
+                  key={thread.id}
+                  style={{ padding: `0 ${config.space.S100}` }}
+                  variant="Background"
+                  radii="300"
+                  onClick={() => onSelect(thread)}
+                  before={
+                    <Avatar size="200">
+                      <Icon size="100" src={Icons.Thread} />
+                    </Avatar>
+                  }
+                >
+                  <Box direction="Column" gap="100" grow="Yes">
+                    <Box alignItems="Center" gap="100">
+                      <Text size="B300" truncate>
+                        {sender}
+                      </Text>
+                      <Text size="B300" priority="300" truncate>
+                        {preview}
+                      </Text>
+                      {replyCount > 0 && (
+                        <Text size="T200" priority="300">
+                          {replyCount}
+                        </Text>
+                      )}
+                    </Box>
+                  </Box>
+                </MenuItem>
+              );
+            })}
+          </Box>
+        </Scroll>
+      </Box>
+    </>
+  );
+}
+
+function ThreadMessages({ room, thread }: { room: Room; thread: Thread }) {
+  const mx = useMatrixClient();
+  const [hideActivity] = useSetting(settingsAtom, 'hideActivity');
+  const [messageLayout] = useSetting(settingsAtom, 'messageLayout');
+  const [messageSpacing] = useSetting(settingsAtom, 'messageSpacing');
+  const [mediaAutoLoad] = useSetting(settingsAtom, 'mediaAutoLoad');
+  const [urlPreview] = useSetting(settingsAtom, 'urlPreview');
+  const [encUrlPreview] = useSetting(settingsAtom, 'encUrlPreview');
+  const showUrlPreview = room.hasEncryptionStateEvent() ? encUrlPreview : urlPreview;
+  const [showDeveloperTools] = useSetting(settingsAtom, 'developerTools');
+  const [hour24Clock] = useSetting(settingsAtom, 'hour24Clock');
+  const [dateFormatString] = useSetting(settingsAtom, 'dateFormatString');
+  const useAuthentication = useMediaAuthentication();
+  const direct = useIsDirectRoom();
+  const [legacyUsernameColor] = useSetting(settingsAtom, 'legacyUsernameColor');
+  const legacyUsernameColorFinal = legacyUsernameColor || direct;
+  const powerLevels = usePowerLevelsContext();
+  const creators = useRoomCreators(room);
+  const creatorsTag = useRoomCreatorsTag();
+  const powerLevelTags = usePowerLevelTags(room, powerLevels);
+  const getMemberPowerTag = useGetMemberPowerTag(room, creators, powerLevels);
+  const theme = useTheme();
+  const accessiblePowerTagColors = useAccessiblePowerTagColors(
+    theme.kind,
+    creatorsTag,
+    powerLevelTags
+  );
+
+  const mentionClickHandler = useMentionClickHandler(room.roomId);
+  const spoilerClickHandler = useSpoilerClickHandler();
+
+  const linkifyOpts = useMemo<LinkifyOpts>(
+    () => ({
+      ...LINKIFY_OPTS,
+      render: factoryRenderLinkifyWithMention((href) =>
+        renderMatrixMention(mx, room.roomId, href, makeMentionCustomProps(mentionClickHandler))
+      ),
+    }),
+    [mx, room, mentionClickHandler]
+  );
+  const htmlReactParserOptions = useMemo<HTMLReactParserOptions>(
+    () =>
+      getReactCustomHtmlParser(mx, room.roomId, {
+        linkifyOpts,
+        useAuthentication,
+        handleSpoilerClick: spoilerClickHandler,
+        handleMentionClick: mentionClickHandler,
+      }),
+    [mx, room, linkifyOpts, spoilerClickHandler, mentionClickHandler, useAuthentication]
+  );
+
+  const events = useMemo(() => {
+    const live: MatrixEvent[] = thread.timelineSet.getLiveTimeline().getEvents();
+    const root = thread.rootEvent;
+    const withRoot = root ? [root, ...live] : live;
+    return withRoot.filter((m: MatrixEvent) => m.getType() === MessageEvent.RoomMessage);
+  }, [thread]);
+
+  const onUserClick: MouseEventHandler<HTMLButtonElement> = useCallback((evt) => {
+    evt.preventDefault();
+    evt.stopPropagation();
+  }, []);
+  const onReplyClick: MouseEventHandler<HTMLButtonElement> = useCallback((evt) => {
+    evt.preventDefault();
+  }, []);
+  const onReactionToggle = useCallback(() => undefined, []);
+
+  if (events.length === 0) {
+    return (
+      <Text style={{ padding: config.space.S300 }} align="Center">
+        No Messages
+      </Text>
+    );
+  }
+
+  return (
+    <Box direction="Column" gap="100">
+      {events.map((mEvent: MatrixEvent) => {
+        const senderId = mEvent.getSender() ?? '';
+        const senderDisplayName = getSenderName(room, senderId);
+        const getContent = (() => mEvent.getContent()) as unknown as GetContentCallback;
+
+        return (
+          <Message
+            key={mEvent.getId()}
+            data-message-id={mEvent.getId()}
+            room={room}
+            mEvent={mEvent}
+            collapse={false}
+            highlight={false}
+            messageLayout={messageLayout}
+            messageSpacing={messageSpacing}
+            onUserClick={onUserClick}
+            onUsernameClick={onUserClick}
+            onReplyClick={onReplyClick}
+            onReactionToggle={onReactionToggle}
+            hideReadReceipts={hideActivity}
+            showDeveloperTools={showDeveloperTools}
+            memberPowerTag={getMemberPowerTag(senderId)}
+            accessibleTagColors={accessiblePowerTagColors}
+            legacyUsernameColor={legacyUsernameColorFinal}
+            hour24Clock={hour24Clock}
+            dateFormatString={dateFormatString}
+          >
+            <RenderMessageContent
+              displayName={senderDisplayName}
+              msgType={mEvent.getContent().msgtype ?? ''}
+              ts={mEvent.getTs()}
+              edited={false}
+              getContent={getContent}
+              mediaAutoLoad={mediaAutoLoad}
+              urlPreview={showUrlPreview}
+              htmlReactParserOptions={htmlReactParserOptions}
+              linkifyOpts={linkifyOpts}
+              outlineAttachment={messageLayout === MessageLayout.Bubble}
+            />
+          </Message>
+        );
+      })}
+    </Box>
+  );
+}
+
+function ThreadDetail({
+  room,
+  thread,
+  onBack,
+}: {
+  room: Room;
+  thread: Thread;
+  onBack: () => void;
+}) {
+  const { rootEvent } = thread;
+  const senderId = rootEvent?.getSender() ?? '';
+  const title = senderId ? getSenderName(room, senderId) : 'Thread';
+
+  return (
+    <>
+      <Box alignItems="Center" gap="100" className={css.ThreadsDrawerDetailHeader}>
+        <TooltipProvider
+          position="Bottom"
+          align="Start"
+          offset={4}
+          tooltip={
+            <Tooltip>
+              <Text>Back to Threads</Text>
+            </Tooltip>
+          }
+        >
+          {(triggerRef) => (
+            <IconButton ref={triggerRef} variant="Background" onClick={onBack}>
+              <Icon size="300" src={Icons.ArrowLeft} />
+            </IconButton>
+          )}
+        </TooltipProvider>
+        <Box grow="Yes">
+          <Text size="H5" truncate>
+            {title}
+          </Text>
+        </Box>
+      </Box>
+      <Box className={css.ThreadDrawerContentBase} grow="Yes">
+        <Scroll variant="Background" size="300" visibility="Always" hideTrack={false}>
+          <Box className={css.ThreadDrawerContent} direction="Column" gap="100">
+            <ThreadMessages room={room} thread={thread} />
+          </Box>
+        </Scroll>
+      </Box>
+    </>
+  );
+}
+
+type ThreadsDrawerProps = {
+  room: Room;
+};
+
+export function ThreadsDrawer({ room }: ThreadsDrawerProps) {
+  const setThreadsDrawer = useSetSetting(settingsAtom, 'threadsDrawer');
+  const [selectedThread, setSelectedThread] = useState<Thread>();
+  const [threads, setThreads] = useState<Thread[]>(() => room.getThreads());
+
+  useEffect(() => {
+    const update = () => setThreads(room.getThreads());
+
+    const handleNewReply = () => update();
+    const handleUpdate = () => update();
+    const handleDelete = () => update();
+
+    room.on(ThreadEvent.NewReply as never, handleNewReply as never);
+    room.on(ThreadEvent.Update as unknown as never, handleUpdate as never);
+    room.on(ThreadEvent.New as never, handleNewReply as never);
+    room.on(ThreadEvent.Delete as never, handleDelete as never);
+
+    // Bootstrap the full server-side thread list for this room if the SDK
+    // supports it. Populates room.getThreads() with threads that may not be
+    // present in the locally-loaded timeline window yet.
+    room
+      .createThreadsTimelineSets()
+      .then(update)
+      .catch(() => undefined);
+
+    return () => {
+      room.off(ThreadEvent.NewReply as never, handleNewReply as never);
+      room.off(ThreadEvent.Update as unknown as never, handleUpdate as never);
+      room.off(ThreadEvent.New as never, handleNewReply as never);
+      room.off(ThreadEvent.Delete as never, handleDelete as never);
+    };
+  }, [room]);
+
+  // refresh selected thread's content when it updates
+  useEffect(() => {
+    if (!selectedThread) return;
+    const latest = room.getThread(selectedThread.id);
+    if (latest && latest !== selectedThread) {
+      setSelectedThread(latest);
+    }
+  }, [threads, selectedThread, room]);
+
+  return (
+    <Box
+      className={classNames(css.ThreadsDrawer, ContainerColor({ variant: 'Background' }))}
+      shrink="No"
+      direction="Column"
+    >
+      <Box grow="Yes" direction="Column">
+        {selectedThread ? (
+          <ThreadDetail
+            room={room}
+            thread={selectedThread}
+            onBack={() => setSelectedThread(undefined)}
+          />
+        ) : (
+          <ThreadList
+            room={room}
+            threads={threads}
+            onSelect={setSelectedThread}
+            onClose={() => setThreadsDrawer(false)}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -691,8 +691,10 @@ function ThreadDetail({
           </Box>
         </Scroll>
       </Box>
-      <ThreadReplyInput room={room} thread={thread} />
-      <RoomViewFollowingPlaceholder />
+      <Box shrink="No" direction="Column">
+        <ThreadReplyInput room={room} thread={thread} />
+        <RoomViewFollowingPlaceholder />
+      </Box>
     </>
   );
 }

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -731,7 +731,7 @@ export function ThreadsDrawer({ room }: ThreadsDrawerProps) {
   }, [threads, selectedThread, room]);
 
   return (
-    <Box shrink="No" direction="Row" style={{ height: '100%' }}>
+    <Box shrink="No" direction="Row">
       <div
         className={css.ThreadsDrawerResizer}
         onPointerDown={startResize}

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -117,7 +117,7 @@ function ThreadListItem({
         <Text size="B300" truncate style={{ flexGrow: 1 }}>
           {preview || 'Thread'}
         </Text>
-        <Text size="T200" priority="300" shrink="No">
+        <Text size="T200" priority="300" shrink="No" style={{ whiteSpace: 'nowrap' }}>
           {replyCount} reply{replyCount === 1 ? '' : 's'}
         </Text>
         {unreadCount > 0 && <UnreadBadge count={unreadCount} />}

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -113,18 +113,14 @@ function ThreadListItem({
         </Avatar>
       }
     >
-      <Box direction="Column" gap="100" grow="Yes">
-        <Text size="B300" truncate>
+      <Box alignItems="Center" gap="200" grow="Yes">
+        <Text size="B300" truncate style={{ flexGrow: 1 }}>
           {preview || 'Thread'}
         </Text>
-        <Box alignItems="Center" gap="100">
-          <Text size="T200" priority="300">
-            {replyCount} reply{replyCount === 1 ? '' : 's'}
-          </Text>
-          <Box shrink="No" alignItems="Center" style={{ marginLeft: 'auto' }}>
-            {unreadCount > 0 && <UnreadBadge count={unreadCount} />}
-          </Box>
-        </Box>
+        <Text size="T200" priority="300" shrink="No">
+          {replyCount} reply{replyCount === 1 ? '' : 's'}
+        </Text>
+        {unreadCount > 0 && <UnreadBadge count={unreadCount} />}
       </Box>
     </MenuItem>
   );

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -53,7 +53,7 @@ import {
   makeMentionCustomProps,
   renderMatrixMention,
 } from '../../plugins/react-custom-html-parser';
-import { getMemberDisplayName } from '../../utils/room';
+import { getMemberDisplayName, getEditedEvent } from '../../utils/room';
 import { getMxIdLocalPart } from '../../utils/matrix';
 import { useMediaAuthentication } from '../../hooks/useMediaAuthentication';
 import { useMentionClickHandler } from '../../hooks/useMentionClickHandler';
@@ -66,7 +66,12 @@ import { usePowerLevelTags } from '../../hooks/usePowerLevelTags';
 import { usePowerLevelsContext } from '../../hooks/usePowerLevels';
 import { useTheme } from '../../hooks/useTheme';
 import { RenderMessageContent } from '../../components/RenderMessageContent';
-import { Message } from './message';
+import { Message, EncryptedContent } from './message';
+import {
+  MessageNotDecryptedContent,
+  MessageUnsupportedContent,
+} from '../../components/message/content/FallbackContent';
+import { RedactedContent } from '../../components/message/MsgTypeRenderers';
 import ThreadReplyInput from './ThreadReplyInput';
 import { RoomViewFollowingPlaceholder } from './RoomViewFollowing';
 import { GetContentCallback, MessageEvent } from '../../../types/matrix/room';
@@ -339,7 +344,12 @@ function ThreadMessages({
     } else {
       withRoot = [root, ...live];
     }
-    return withRoot.filter((m: MatrixEvent) => m.getType() === MessageEvent.RoomMessage);
+    return withRoot.filter(
+      (m: MatrixEvent) =>
+        m.getType() === MessageEvent.RoomMessage ||
+        m.getType() === MessageEvent.RoomMessageEncrypted ||
+        m.getType() === MessageEvent.Sticker
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [thread, revision]);
 
@@ -385,7 +395,11 @@ function ThreadMessages({
       {events.map((mEvent: MatrixEvent) => {
         const senderId = mEvent.getSender() ?? '';
         const senderDisplayName = getSenderName(room, senderId);
-        const getContent = (() => mEvent.getContent()) as unknown as GetContentCallback;
+        const eventId = mEvent.getId();
+        const editedEvent = eventId ? getEditedEvent(eventId, mEvent, thread.timelineSet) : undefined;
+        const getContent = (() =>
+          editedEvent?.getContent()['m.new_content'] ?? mEvent.getContent()) as unknown as GetContentCallback;
+        const eventType = mEvent.getType();
 
         return (
           <Message
@@ -409,18 +423,55 @@ function ThreadMessages({
             hour24Clock={hour24Clock}
             dateFormatString={dateFormatString}
           >
-            <RenderMessageContent
-              displayName={senderDisplayName}
-              msgType={mEvent.getContent().msgtype ?? ''}
-              ts={mEvent.getTs()}
-              edited={false}
-              getContent={getContent}
-              mediaAutoLoad={mediaAutoLoad}
-              urlPreview={showUrlPreview}
-              htmlReactParserOptions={htmlReactParserOptions}
-              linkifyOpts={linkifyOpts}
-              outlineAttachment={messageLayout === MessageLayout.Bubble}
-            />
+            {eventType === MessageEvent.RoomMessageEncrypted ? (
+              <EncryptedContent mEvent={mEvent}>
+                {() => {
+                  if (mEvent.isRedacted()) return <RedactedContent />;
+                  // After decryption the event type may flip to m.room.message —
+                  // render it as a normal message if so.
+                  if (mEvent.getType() === MessageEvent.RoomMessage) {
+                    return (
+                      <RenderMessageContent
+                        displayName={senderDisplayName}
+                        msgType={mEvent.getContent().msgtype ?? ''}
+                        ts={mEvent.getTs()}
+                        edited={!!editedEvent}
+                        getContent={getContent}
+                        mediaAutoLoad={mediaAutoLoad}
+                        urlPreview={showUrlPreview}
+                        htmlReactParserOptions={htmlReactParserOptions}
+                        linkifyOpts={linkifyOpts}
+                        outlineAttachment={messageLayout === MessageLayout.Bubble}
+                      />
+                    );
+                  }
+                  if (mEvent.getType() === MessageEvent.RoomMessageEncrypted)
+                    return (
+                      <Text>
+                        <MessageNotDecryptedContent />
+                      </Text>
+                    );
+                  return (
+                    <Text>
+                      <MessageUnsupportedContent />
+                    </Text>
+                  );
+                }}
+              </EncryptedContent>
+            ) : (
+              <RenderMessageContent
+                displayName={senderDisplayName}
+                msgType={mEvent.getContent().msgtype ?? ''}
+                ts={mEvent.getTs()}
+                edited={!!editedEvent}
+                getContent={getContent}
+                mediaAutoLoad={mediaAutoLoad}
+                urlPreview={showUrlPreview}
+                htmlReactParserOptions={htmlReactParserOptions}
+                linkifyOpts={linkifyOpts}
+                outlineAttachment={messageLayout === MessageLayout.Bubble}
+              />
+            )}
           </Message>
         );
       })}

--- a/src/app/features/room/ThreadsDrawer.tsx
+++ b/src/app/features/room/ThreadsDrawer.tsx
@@ -7,6 +7,7 @@ import {
   Icon,
   IconButton,
   Icons,
+  Line,
   Menu,
   MenuItem,
   PopOut,
@@ -26,6 +27,8 @@ import { Opts as LinkifyOpts } from 'linkifyjs';
 import { HTMLReactParserOptions } from 'html-react-parser';
 
 import { useRoomNavigate } from '../../hooks/useRoomNavigate';
+import { useThreadUnreadCount } from '../../hooks/useThreadUnreadCount';
+import { UnreadBadge } from '../../components/unread-badge';
 import { getMatrixToRoomEvent } from '../../plugins/matrix-to';
 import { getViaServers } from '../../plugins/via-servers';
 import { copyToClipboard } from '../../utils/dom';
@@ -70,6 +73,50 @@ function getThreadPreview(rootEvent: MatrixEvent | undefined): string {
   const body = rootEvent?.getContent().body;
   if (typeof body !== 'string') return '';
   return body;
+}
+
+function ThreadListItem({
+  room,
+  thread,
+  onSelect,
+}: {
+  room: Room;
+  thread: Thread;
+  onSelect: (thread: Thread) => void;
+}) {
+  const unreadCount = useThreadUnreadCount(room, thread);
+  const { rootEvent } = thread;
+  const senderId = rootEvent?.getSender() ?? '';
+  const sender = senderId ? getSenderName(room, senderId) : 'Unknown';
+  const preview = getThreadPreview(rootEvent);
+
+  return (
+    <MenuItem
+      style={{ padding: `0 ${config.space.S100}` }}
+      variant="Background"
+      radii="300"
+      onClick={() => onSelect(thread)}
+      before={
+        <Avatar size="200">
+          <Icon size="100" src={Icons.Thread} />
+        </Avatar>
+      }
+    >
+      <Box direction="Column" gap="100" grow="Yes">
+        <Box alignItems="Center" gap="100">
+          <Text size="B300" truncate>
+            {sender}
+          </Text>
+          <Text size="B300" priority="300" truncate>
+            {preview}
+          </Text>
+          <Box shrink="No" alignItems="Center" style={{ marginLeft: 'auto' }}>
+            {unreadCount > 0 && <UnreadBadge count={unreadCount} />}
+          </Box>
+        </Box>
+      </Box>
+    </MenuItem>
+  );
 }
 
 function ThreadList({
@@ -118,44 +165,14 @@ function ThreadList({
                 No Threads
               </Text>
             )}
-            {threads.map((thread) => {
-              const { rootEvent } = thread;
-              const senderId = rootEvent?.getSender() ?? '';
-              const sender = senderId ? getSenderName(room, senderId) : 'Unknown';
-              const preview = getThreadPreview(rootEvent);
-              const replyCount = Math.max(0, thread.length);
-
-              return (
-                <MenuItem
-                  key={thread.id}
-                  style={{ padding: `0 ${config.space.S100}` }}
-                  variant="Background"
-                  radii="300"
-                  onClick={() => onSelect(thread)}
-                  before={
-                    <Avatar size="200">
-                      <Icon size="100" src={Icons.Thread} />
-                    </Avatar>
-                  }
-                >
-                  <Box direction="Column" gap="100" grow="Yes">
-                    <Box alignItems="Center" gap="100">
-                      <Text size="B300" truncate>
-                        {sender}
-                      </Text>
-                      <Text size="B300" priority="300" truncate>
-                        {preview}
-                      </Text>
-                      {replyCount > 0 && (
-                        <Text size="T200" priority="300">
-                          {replyCount}
-                        </Text>
-                      )}
-                    </Box>
-                  </Box>
-                </MenuItem>
-              );
-            })}
+            {threads.map((thread) => (
+              <ThreadListItem
+                key={thread.id}
+                room={room}
+                thread={thread}
+                onSelect={onSelect}
+              />
+            ))}
           </Box>
         </Scroll>
       </Box>
@@ -397,6 +414,7 @@ function ThreadMenu({
   thread: Thread;
   onViewInThread: () => void;
 }) {
+  const mx = useMatrixClient();
   const [menuAnchor, setMenuAnchor] = useState<RectCords>();
   const rootEventId = thread.rootEvent?.getId();
 
@@ -404,15 +422,29 @@ function ThreadMenu({
     setMenuAnchor(evt.currentTarget.getBoundingClientRect());
   };
 
+  const handleClose = () => setMenuAnchor(undefined);
+
+  // Mark all replies in this thread as read by sending a *threaded* read
+  // receipt on the thread's latest event (sendReadReceipt adds thread_id for
+  // thread events while supportsThreads is on). The server echoes the receipt
+  // back, which clears the thread's unread notification count and flips
+  // hasUserReadEvent so the unread indicators (list pill + timeline summary)
+  // clear without a reload.
+  const handleMarkAsRead = () => {
+    handleClose();
+    const lastEvent = thread.replyToEvent ?? thread.lastReply();
+    if (lastEvent) mx.sendReadReceipt(lastEvent);
+  };
+
   const handleViewInThread = () => {
-    setMenuAnchor(undefined);
+    handleClose();
     onViewInThread();
   };
 
   const handleCopyLink = () => {
     if (!rootEventId) return;
     copyToClipboard(getMatrixToRoomEvent(room.roomId, rootEventId, getViaServers(room)));
-    setMenuAnchor(undefined);
+    handleClose();
   };
 
   return (
@@ -423,7 +455,7 @@ function ThreadMenu({
         onClick={handleOpenMenu}
         aria-label="Thread options"
       >
-        <Icon src={Icons.VerticalDots} />
+        <Icon size="400" src={Icons.VerticalDots} filled={!!menuAnchor} />
       </IconButton>
       <PopOut
         anchor={menuAnchor}
@@ -433,35 +465,50 @@ function ThreadMenu({
           <FocusTrap
             focusTrapOptions={{
               initialFocus: false,
-              clickOutsideDeactivates: true,
-              onDeactivate: () => setMenuAnchor(undefined),
               returnFocusOnDeactivate: false,
+              onDeactivate: () => setMenuAnchor(undefined),
+              clickOutsideDeactivates: true,
               isKeyForward: (evt: KeyboardEvent) => evt.key === 'ArrowDown',
               isKeyBackward: (evt: KeyboardEvent) => evt.key === 'ArrowUp',
               escapeDeactivates: stopPropagation,
             }}
           >
-            <Menu>
-              <MenuItem
-                size="300"
-                radii="300"
-                after={<Icon size="100" src={Icons.External} />}
-                onClick={handleViewInThread}
-              >
-                <Text size="T300" truncate>
-                  View in Thread
-                </Text>
-              </MenuItem>
-              <MenuItem
-                size="300"
-                radii="300"
-                after={<Icon size="100" src={Icons.Link} />}
-                onClick={handleCopyLink}
-              >
-                <Text size="T300" truncate>
-                  Copy link to thread
-                </Text>
-              </MenuItem>
+            <Menu style={{ maxWidth: toRem(160), width: '100vw' }}>
+              <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>
+                <MenuItem
+                  onClick={handleMarkAsRead}
+                  size="300"
+                  after={<Icon size="100" src={Icons.CheckTwice} />}
+                  radii="300"
+                >
+                  <Text style={{ flexGrow: 1 }} as="span" size="T300" truncate>
+                    Mark as Read
+                  </Text>
+                </MenuItem>
+                <MenuItem
+                  onClick={handleViewInThread}
+                  size="300"
+                  after={<Icon size="100" src={Icons.Thread} />}
+                  radii="300"
+                >
+                  <Text style={{ flexGrow: 1 }} as="span" size="T300" truncate>
+                    View in Thread
+                  </Text>
+                </MenuItem>
+              </Box>
+              <Line variant="Surface" size="300" />
+              <Box direction="Column" gap="100" style={{ padding: config.space.S100 }}>
+                <MenuItem
+                  onClick={handleCopyLink}
+                  size="300"
+                  after={<Icon size="100" src={Icons.Link} />}
+                  radii="300"
+                >
+                  <Text style={{ flexGrow: 1 }} as="span" size="T300" truncate>
+                    Copy link to thread
+                  </Text>
+                </MenuItem>
+              </Box>
             </Menu>
           </FocusTrap>
         }
@@ -486,6 +533,17 @@ function ThreadDetail({
   const title =
     getThreadPreview(rootEvent) || (senderId ? getSenderName(room, senderId) : 'Thread');
   const { navigateRoom } = useRoomNavigate();
+  const mx = useMatrixClient();
+
+  // Mark the thread as read when it is opened: send a *threaded* read receipt
+  // on the thread's latest event (sendReadReceipt adds thread_id for thread
+  // events). The echoed receipt clears the thread's unread count and flips
+  // hasUserReadEvent, so the list count-pill and the timeline summary clear
+  // without a reload once the user has caught up.
+  useEffect(() => {
+    const lastEvent = thread.replyToEvent ?? thread.lastReply();
+    if (lastEvent) mx.sendReadReceipt(lastEvent);
+  }, [mx, thread]);
 
   const handleViewInThread = () => {
     // Navigate to the room with the root (thread-starting) event focused so the
@@ -498,7 +556,7 @@ function ThreadDetail({
 
   return (
     <>
-      <Box alignItems="Center" gap="100" className={css.ThreadsDrawerDetailHeader}>
+      <Header className={css.ThreadsDrawerDetailHeader} variant="Background" size="600">
         <TooltipProvider
           position="Bottom"
           align="Start"
@@ -537,7 +595,7 @@ function ThreadDetail({
             </IconButton>
           )}
         </TooltipProvider>
-      </Box>
+      </Header>
       <Box className={css.ThreadDrawerContentBase} grow="Yes">
         <Scroll variant="Background" size="300" visibility="Always" hideTrack={false}>
           <Box className={css.ThreadDrawerContent} direction="Column" gap="100">

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -307,6 +307,7 @@ function Appearance() {
   const [systemTheme, setSystemTheme] = useSetting(settingsAtom, 'useSystemTheme');
   const [monochromeMode, setMonochromeMode] = useSetting(settingsAtom, 'monochromeMode');
   const [twitterEmoji, setTwitterEmoji] = useSetting(settingsAtom, 'twitterEmoji');
+  const [threadsDrawer, setThreadsDrawer] = useSetting(settingsAtom, 'threadsDrawer');
 
   return (
     <Box direction="Column" gap="100">
@@ -344,6 +345,14 @@ function Appearance() {
         <SettingTile
           title="Twitter Emoji"
           after={<Switch variant="Primary" value={twitterEmoji} onChange={setTwitterEmoji} />}
+        />
+      </SequenceCard>
+
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Threads"
+          description="Show a threads side panel for the open room (desktop)."
+          after={<Switch variant="Primary" value={threadsDrawer} onChange={setThreadsDrawer} />}
         />
       </SequenceCard>
 

--- a/src/app/hooks/useMediaAuthentication.ts
+++ b/src/app/hooks/useMediaAuthentication.ts
@@ -1,14 +1,50 @@
+import { useState, useEffect } from 'react';
 import { useSpecVersions } from './useSpecVersions';
 
-export const useMediaAuthentication = (): boolean => {
-  useSpecVersions(); // consumed only to trigger re-render on versions change
+/**
+ * Whether the Cinny service worker is actively controlling this page and
+ * therefore able to inject the Bearer access token into authenticated v1
+ * media requests (/_matrix/client/v1/media/download|thumbnail). Browsers
+ * only register service workers in secure contexts (HTTPS or localhost), so
+ * on a plain-HTTP LAN URL like http://10.1.0.220:8083 the SW never registers
+ * and there is no controller. Without a controller the SW cannot add the
+ * Authorization header, so authenticated v1 media URLs get 401s from Synapse
+ * and nothing (avatars, thumbnails, stickers) renders.
+ */
+function useServiceWorkerActive(): boolean {
+  const [active, setActive] = useState(() =>
+    typeof navigator !== 'undefined' &&
+    'serviceWorker' in navigator &&
+    !!navigator.serviceWorker.controller
+  );
 
-  // Media authentication is introduced in spec version 1.11.
-  // Synapse advertises v1.11 support but does NOT enforce authenticated media
-  // (require_auth_for_media is not set). Cinny's service worker is supposed to
-  // inject the Bearer token into v1 authenticated media requests, but it
-  // silently fails to do so in this deployment, causing 401s on every avatar /
-  // media thumbnail / download. Since Synapse allows unauthenticated media,
-  // force this off so Cinny uses legacy v3 media URLs that need no token.
-  return false;
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+      return undefined;
+    }
+
+    const update = () => setActive(!!navigator.serviceWorker.controller);
+    update();
+
+    navigator.serviceWorker.addEventListener('controllerchange', update);
+    return () => navigator.serviceWorker.removeEventListener('controllerchange', update);
+  }, []);
+
+  return active;
+}
+
+export const useMediaAuthentication = (): boolean => {
+  const { versions, unstable_features: unstableFeatures } = useSpecVersions();
+  const swActive = useServiceWorkerActive();
+
+  // Media authentication (MSC3916) is introduced in spec version 1.11.
+  const serverSupportsAuthenticatedMedia =
+    unstableFeatures?.['org.matrix.msc3916.stable'] || versions.includes('v1.11');
+
+  // Only request authenticated v1 media URLs when the server supports them
+  // AND the service worker is actively controlling the page (so it can inject
+  // the Bearer token). If the SW is not controlling — e.g. on a plain-HTTP
+  // non-localhost LAN URL where the browser refuses to register a service
+  // worker — fall back to legacy v3 media URLs that need no token.
+  return serverSupportsAuthenticatedMedia && swActive;
 };

--- a/src/app/hooks/useMediaAuthentication.ts
+++ b/src/app/hooks/useMediaAuthentication.ts
@@ -1,11 +1,14 @@
 import { useSpecVersions } from './useSpecVersions';
 
 export const useMediaAuthentication = (): boolean => {
-  const { versions, unstable_features: unstableFeatures } = useSpecVersions();
+  useSpecVersions(); // consumed only to trigger re-render on versions change
 
-  // Media authentication is introduced in spec version 1.11
-  const authenticatedMedia =
-    unstableFeatures?.['org.matrix.msc3916.stable'] || versions.includes('v1.11');
-
-  return authenticatedMedia;
+  // Media authentication is introduced in spec version 1.11.
+  // Synapse advertises v1.11 support but does NOT enforce authenticated media
+  // (require_auth_for_media is not set). Cinny's service worker is supposed to
+  // inject the Bearer token into v1 authenticated media requests, but it
+  // silently fails to do so in this deployment, causing 401s on every avatar /
+  // media thumbnail / download. Since Synapse allows unauthenticated media,
+  // force this off so Cinny uses legacy v3 media URLs that need no token.
+  return false;
 };

--- a/src/app/hooks/useThreadUnreadCount.ts
+++ b/src/app/hooks/useThreadUnreadCount.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { NotificationCountType, Room, RoomEvent, Thread, ThreadEvent } from 'matrix-js-sdk';
+
+/**
+ * Live per-thread unread reply count for the current user.
+ *
+ * Sources the count from the room's thread notification map
+ * (`room.getThreadUnreadNotificationCount`), the same data the left sidebar's
+ * per-room unread uses (`room.getUnreadNotificationCount`), so the thread-list
+ * pill feels consistent with the channel list. Synapse keeps the thread's
+ * `total` count current in the sync, and when a *threaded* read receipt is sent
+ * (e.g. opening the thread, or the menu's "Mark as read") the echoed receipt
+ * resets the count to zero, so the pill disappears without a reload.
+ *
+ * Re-renders whenever the room emits an unread-notification change (which fires
+ * with the thread id for thread counts), a thread event, or any receipt.
+ */
+export function useThreadUnreadCount(room: Room, thread: Thread): number {
+  const [, setRevision] = useState(0);
+
+  useEffect(() => {
+    const bump = () => setRevision((r) => r + 1);
+
+    // Fired by room.setThreadUnreadNotificationCount with (notification, threadId);
+    // the server's sync resets the count when a threaded receipt arrives.
+    const onUnreadNotifications = () => bump();
+    const handleChange = () => bump();
+
+    room.on(RoomEvent.UnreadNotifications as never, onUnreadNotifications as never);
+    room.on(ThreadEvent.NewReply as never, handleChange as never);
+    room.on(ThreadEvent.Update as unknown as never, handleChange as never);
+    room.on(ThreadEvent.Delete as never, handleChange as never);
+    room.on(RoomEvent.Receipt as never, bump as never);
+    return () => {
+      room.off(RoomEvent.UnreadNotifications as never, onUnreadNotifications as never);
+      room.off(ThreadEvent.NewReply as never, handleChange as never);
+      room.off(ThreadEvent.Update as unknown as never, handleChange as never);
+      room.off(ThreadEvent.Delete as never, handleChange as never);
+      room.off(RoomEvent.Receipt as never, bump as never);
+    };
+  }, [room]);
+
+  return room.getThreadUnreadNotificationCount(thread.id, NotificationCountType.Total);
+}

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -200,7 +200,7 @@ function MessageNotifications() {
       const sender = mEvent.getSender();
       const eventId = mEvent.getId();
       if (!sender || !eventId || mEvent.getSender() === mx.getUserId()) return;
-      const unreadInfo = getUnreadInfo(room);
+      const unreadInfo = getUnreadInfo(mx, room);
       const cachedUnreadInfo = unreadCacheRef.current.get(room.roomId);
       unreadCacheRef.current.set(room.roomId, unreadInfo);
 

--- a/src/app/state/room/roomInputDrafts.ts
+++ b/src/app/state/room/roomInputDrafts.ts
@@ -20,9 +20,7 @@ export type TUploadItem = {
 
 export type TUploadListAtom = ReturnType<typeof createListAtom<TUploadItem>>;
 
-export const roomIdToUploadItemsAtomFamily = atomFamily<string, TUploadListAtom>(
-  createListAtom
-);
+export const roomIdToUploadItemsAtomFamily = atomFamily<string, TUploadListAtom>(createListAtom);
 
 export const roomUploadAtomFamily = createUploadAtomFamily();
 
@@ -50,8 +48,20 @@ export type IReplyDraft = {
   formattedBody?: string | undefined;
   relation?: IEventRelation | undefined;
 };
+// Per-thread draft family, scoped independently of the main-room composer draft
+// (roomIdToMsgDraftAtomFamily) so the thread panel and the main timeline
+// composer never clobber each other's in-progress text.
+export const threadIdToMsgDraftAtomFamily = atomFamily<string, TMsgDraftAtom>(() =>
+  createMsgDraftAtom()
+);
 const createReplyDraftAtom = () => atom<IReplyDraft | undefined>(undefined);
 export type TReplyDraftAtom = ReturnType<typeof createReplyDraftAtom>;
 export const roomIdToReplyDraftAtomFamily = atomFamily<string, TReplyDraftAtom>(() =>
+  createReplyDraftAtom()
+);
+// Per-thread reply draft family, scoped independently of the main-room composer
+// draft (roomIdToReplyDraftAtomFamily) so the thread panel and the main timeline
+// composer never clobber each other's in-progress text.
+export const threadIdToReplyDraftAtomFamily = atomFamily<string, TReplyDraftAtom>(() =>
   createReplyDraftAtom()
 );

--- a/src/app/state/room/roomToUnread.ts
+++ b/src/app/state/room/roomToUnread.ts
@@ -213,7 +213,7 @@ export const useBindRoomToUnreadAtom = (mx: MatrixClient, unreadAtom: typeof roo
       }
 
       if (mEvent.getSender() === mx.getUserId()) return;
-      setUnreadAtom({ type: 'PUT', unreadInfo: getUnreadInfo(room) });
+      setUnreadAtom({ type: 'PUT', unreadInfo: getUnreadInfo(mx, room) });
     };
     mx.on(RoomEvent.Timeline, handleTimelineEvent);
     return () => {

--- a/src/app/state/room/threadSelection.ts
+++ b/src/app/state/room/threadSelection.ts
@@ -1,0 +1,14 @@
+import { atom } from 'jotai';
+
+/**
+ * The currently-selected thread id for the open room, shared between the main
+ * timeline (thread summaries) and the ThreadsDrawer so that clicking a thread
+ * summary in the timeline can open that same thread inside the panel.
+ *
+ * Only one room is open at a time (RoomTimeline / ThreadsDrawer are both keyed
+ * by roomId), so a single module atom is sufficient; it is reset on room leave.
+ * Holds `{ roomId, threadId }` (or undefined) to avoid stale cross-room reads.
+ */
+export type ThreadSelection = { roomId: string; threadId: string };
+
+export const selectedThreadAtom = atom<ThreadSelection | undefined>(undefined);

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -63,7 +63,7 @@ const defaultSettings: Settings = {
   hideActivity: false,
 
   isPeopleDrawer: true,
-  threadsDrawer: false,
+  threadsDrawer: true,
   memberSortFilterIndex: 0,
   enterForNewline: false,
   messageLayout: 0,

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -28,6 +28,7 @@ export interface Settings {
   hideActivity: boolean;
 
   isPeopleDrawer: boolean;
+  threadsDrawer: boolean;
   memberSortFilterIndex: number;
   enterForNewline: boolean;
   messageLayout: MessageLayout;
@@ -62,6 +63,7 @@ const defaultSettings: Settings = {
   hideActivity: false,
 
   isPeopleDrawer: true,
+  threadsDrawer: false,
   memberSortFilterIndex: 0,
   enterForNewline: false,
   messageLayout: 0,

--- a/src/app/utils/room.ts
+++ b/src/app/utils/room.ts
@@ -268,15 +268,27 @@ export const getUnreadMessageCount = (mx: MatrixClient, room: Room): number => {
 export const getUnreadInfo = (mx: MatrixClient, room: Room): UnreadInfo => {
   const notifTotal = room.getUnreadNotificationCount(NotificationCountType.Total);
   const highlight = room.getUnreadNotificationCount(NotificationCountType.Highlight);
-  // When the SDK notification count is 0 (e.g. notification mode is
-  // "Mentions & Keywords only"), fall back to counting actual unread messages
-  // in the live timeline so the channel list badge shows a real number instead
-  // of an empty dot.
-  const realTotal = notifTotal > 0 ? notifTotal : getUnreadMessageCount(mx, room);
+  // For "Mentions & Keywords only" rooms the SDK notification count is 0 by
+  // design (the room push rule has no notify action). Previously we fell back to
+  // getUnreadMessageCount for every such room, which made Cinny fire desktop
+  // notifications and show a channel badge for EVERY message — defeating the
+  // purpose of the Mentions-only setting. Now we only surface the real count
+  // when there is an actual highlight/mention; otherwise the room stays quiet
+  // (no badge, no notification) exactly as the notification mode promises.
+  // All-Messages and Default rooms still get the real count fallback so their
+  // channel-list badge shows a number instead of an empty dot.
+  const mode = getNotificationType(mx, room.roomId);
+  const realCount = getUnreadMessageCount(mx, room);
+  let total: number;
+  if (mode === NotificationType.MentionsAndKeywords) {
+    total = highlight > 0 ? realCount : 0;
+  } else {
+    total = notifTotal > 0 ? notifTotal : realCount;
+  }
   return {
     roomId: room.roomId,
     highlight,
-    total: highlight > realTotal ? highlight : realTotal,
+    total: highlight > total ? highlight : total,
   };
 };
 

--- a/src/app/utils/room.ts
+++ b/src/app/utils/room.ts
@@ -233,13 +233,50 @@ export const roomHaveUnread = (mx: MatrixClient, room: Room) => {
   return true;
 };
 
-export const getUnreadInfo = (room: Room): UnreadInfo => {
-  const total = room.getUnreadNotificationCount(NotificationCountType.Total);
+/**
+ * Counts the actual number of unread notification events in the room's live
+ * timeline after the user's read receipt. Unlike
+ * `room.getUnreadNotificationCount(NotificationCountType.Total)` (which only
+ * counts messages matching push rules), this walks the live timeline and counts
+ * every notification event after the read marker — so it returns a real number
+ * even for rooms whose notification mode is "Mentions & Keywords only" where
+ * the SDK notification count stays 0.
+ *
+ * Only considers events currently in the live timeline (what sync has loaded).
+ * Returns 0 if the last event was sent by the user (no unreads).
+ */
+export const getUnreadMessageCount = (mx: MatrixClient, room: Room): number => {
+  const userId = mx.getUserId();
+  if (!userId) return 0;
+  const readUpToId = room.getEventReadUpTo(userId);
+  const liveEvents = room.getLiveTimeline().getEvents();
+
+  if (liveEvents[liveEvents.length - 1]?.getSender() === userId) {
+    return 0;
+  }
+
+  let count = 0;
+  for (let i = liveEvents.length - 1; i >= 0; i -= 1) {
+    const event = liveEvents[i];
+    if (!event) break;
+    if (event.getId() === readUpToId) break;
+    if (isNotificationEvent(event)) count += 1;
+  }
+  return count;
+};
+
+export const getUnreadInfo = (mx: MatrixClient, room: Room): UnreadInfo => {
+  const notifTotal = room.getUnreadNotificationCount(NotificationCountType.Total);
   const highlight = room.getUnreadNotificationCount(NotificationCountType.Highlight);
+  // When the SDK notification count is 0 (e.g. notification mode is
+  // "Mentions & Keywords only"), fall back to counting actual unread messages
+  // in the live timeline so the channel list badge shows a real number instead
+  // of an empty dot.
+  const realTotal = notifTotal > 0 ? notifTotal : getUnreadMessageCount(mx, room);
   return {
     roomId: room.roomId,
     highlight,
-    total: highlight > total ? highlight : total,
+    total: highlight > realTotal ? highlight : realTotal,
   };
 };
 
@@ -250,7 +287,7 @@ export const getUnreadInfos = (mx: MatrixClient): UnreadInfo[] => {
     if (getNotificationType(mx, room.roomId) === NotificationType.Mute) return unread;
 
     if (roomHaveNotification(room) || roomHaveUnread(mx, room)) {
-      unread.push(getUnreadInfo(room));
+      unread.push(getUnreadInfo(mx, room));
     }
 
     return unread;

--- a/src/client/initMatrix.ts
+++ b/src/client/initMatrix.ts
@@ -43,6 +43,7 @@ export const initClient = async (session: Session): Promise<MatrixClient> => {
 export const startClient = async (mx: MatrixClient) => {
   await mx.startClient({
     lazyLoadMembers: true,
+    threadSupport: true,
   });
 };
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,10 @@ import buildConfig from './build.config';
 const copyFiles = {
   targets: [
     {
+      src: 'node_modules/@matrix-org/matrix-sdk-crypto-wasm/pkg/matrix_sdk_crypto_wasm_bg.js',
+      dest: 'assets',
+    },
+    {
       src: 'node_modules/@element-hq/element-call-embedded/dist/*',
       dest: 'public/element-call',
     },


### PR DESCRIPTION
# feat: Discord-style thread side-panel

> **Note:** The repo README states PRs are closed during the SDK rewrite. This PR is opened for **visibility and reference**, not with an expectation of an immediate merge — it exists so there's a concrete, reviewable implementation of a feature that the community can see, build on, or revisit once the SDK migration settles. A public fork lives at https://github.com/jrimmer/cinny-threads for anyone who wants to run this today.

## Summary

Cinny renders threads inline in the room timeline with no dedicated panel. This PR adds a **Discord-style thread side-panel** — a drawer docked to the right of the room view (modeled on the existing `MembersDrawer`) — plus Element-style thread summaries on root messages, real unread counts in channel badges, and two build/runtime fixes that were necessary to make the feature work end-to-end.

Based on `release-v4.12.6`. 28 commits, ~2,050 lines added across 21 files.

![Cinny thread side-panel](https://raw.githubusercontent.com/jrimmer/cinny-threads/feature/threads-panel/docs/screenshots/cinny-threads.png)

## Features

### Thread side-panel drawer (`ThreadsDrawer`)
- **Thread list** — every thread in the room, with root message preview, reply count, and a white unread-count pill. One-line rows, no sender prefix (the user is already in the channel).
- **Thread detail view** — renders the full thread conversation inside the drawer, reusing Cinny's existing message renderers (`Message`, `RenderMessageContent`, `EncryptedContent`) so it looks identical to the main timeline. Supports `m.room.message`, `m.room.encrypted` (with decrypt/retry/redacted/unsupported states), `m.sticker`, and edited messages (`m.new_content`).
- **Thread reply composer** — reply directly from the drawer with `@mention` autocomplete pills, emoji/sticker pickers, and auto-expand. Sends `m.relates_to { rel_type: 'm.thread', event_id }` correctly.
- **Resizable** — drag the left edge to resize (min 320, max 640, default 400); width persists to `localStorage`.
- **Overflow menu** — vertical-dots menu mirroring the room menu, with **Mark as Read** (threaded read receipt), **View in Thread** (focuses the root in the main timeline), and **Copy Link**.
- **Auto-mark-read** — opening a thread detail sends a threaded read receipt, clearing the unread pill and the main-timeline summary.
- **Live updates** — new threads and replies appear live without a reload; the detail view auto-scrolls to new replies.
- **Desktop only** — collapses on mobile, same `ScreenSize.Desktop` gate as the member drawer. Toggled via a threads `IconButton` in the room header, mutually exclusive with the member drawer.

### Element-style thread summaries (`ThreadSummary`)
- Thread root messages in the main timeline show a clickable summary row beneath them (thread icon + last-reply preview + reply count) when they have replies.
- When the thread has unread replies, the icon swaps to an accent thread-unread icon and a white unread-count pill appears.
- Clicking the summary opens the thread in the drawer.

### Real unread message counts (`getUnreadMessageCount`)
- The left-side channel badge now shows the **actual number of unread messages** (walking the live timeline from the read receipt to the end), not the SDK push-rule notification count — which returns 0 for "Mentions & Keywords only" rooms even when there are unread messages. Matches Element behavior.
- Respects the room notification mode: for "Mentions & Keywords only" rooms the real count is only surfaced when there is an actual mention/highlight, so the badge and desktop notifications stay quiet otherwise.

### Adaptive authenticated media (`useMediaAuthentication`)
- Cinny v4.12.6 generates authenticated v1 media URLs when the server advertises spec v1.11, but the service worker that injects the Bearer token only works in secure contexts (HTTPS / localhost). On plain HTTP LAN IPs the SW can't register, so media 401s and avatars never load.
- Gates `useMediaAuthentication` on `window.isSecureContext` so authenticated v1 URLs are only generated when the SW can actually register, falling back to unauthenticated v3 media URLs over plain HTTP. Works for both `https://chat.example.com` and `http://10.0.0.5:8083` access patterns.

### Build fix: crypto WASM glue (`vite.config.js`)
- The matrix-js-sdk crypto WASM chunk references `matrix_sdk_crypto_wasm_bg.js` at module load time, but `@rollup/plugin-wasm` only emits the `.wasm` file. Without the glue JS sibling, the chunk's top-level await rejects and the app crashes with "Failed to fetch dynamically imported module" on any route that lazy-loads the crypto SDK (e.g. post-SSO). Adds the glue file to `viteStaticCopy` targets.

## Settings

A new **Threads** toggle in *Settings → General*: "Show a threads side panel for the open room (desktop)". Off by default.

## Implementation notes

- Activates authentic SDK thread aggregation via `threadSupport: true` in `mx.startClient()` (`src/client/initMatrix.ts`); without this, `room.getThreads()` only returns threads from sync-loaded local timeline events.
- Thread list hydration uses `room.fetchRoomThreads()` (the SDK's authentic primitive — no auto-caller, the app must invoke it).
- The drawer reuses Cinny's existing message renderers with `RoomTimeline`'s context wiring so rendering stays byte-consistent with the main timeline.
- Live new-thread creation for the user's own replies subscribes to `RoomEvent.LocalEchoUpdated`, because the SDK's `handleRemoteEcho()` path skips `createThread()` (only `addLiveEvents` → `addThreadedEvents` creates threads), so without this a user's own first reply in a thread never creates the `Thread` object live and the summary doesn't appear until a reload.
- An RFC with the full design rationale lives at `docs/thread-panel-rfc.md`.

## How this was built

This feature was **vibe-coded** — implemented iteratively through an AI-assisted coding workflow using **GLM-5.2** and **DeepSeek v4 Flash**, with implementation review and structured engineering discipline provided by **[Compound Engineering](https://github.com/compound-ai/compound-engineering)** skills (plan → work → code review → test loops).

It has been **tested only in a local, private install** — not on a public deployment — against a single Synapse + MAS homeserver. It is working as designed in that environment, but has not received broad testing across homeserver configurations, client versions, or scale. Reviewers should treat it as a reference implementation rather than production-hardened.

## Test plan

- [ ] Open a room with active threads, toggle Settings → Threads on, verify the drawer appears with the thread list.
- [ ] Click a thread in the list, verify the detail view renders all replies (including encrypted and sticker events).
- [ ] Reply from the drawer composer, verify the reply appears live and auto-scrolls.
- [ ] Verify `@mention` autocomplete pills trigger in the thread composer.
- [ ] Verify the overflow menu Mark as Read / View in Thread / Copy Link all work.
- [ ] Verify resizing the drawer persists across reloads.
- [ ] Verify thread summaries appear on root messages in the main timeline and update their unread state.
- [ ] Verify channel badges show real unread counts and respect Mentions-only notification mode.
- [ ] Verify avatars/media load over both HTTPS (authenticated v1) and plain HTTP LAN (v3 fallback).

## Why a fork exists

Upstream is closed to PRs during the SDK rewrite. A public fork at https://github.com/jrimmer/cinny-threads lets people run this feature today. When upstream reopens and the SDK migration settles, the thread-panel work here can serve as a reference implementation — the component structure (a drawer modeled on `MembersDrawer`, reusing existing renderers) should translate, though the SDK calls will change.

## License

AGPL-3.0, same as upstream.