### PR TITLE
fix: Check m.room.encrypted permission for composer in encrypted rooms

### DIFF
--- a/src/app/features/room/RoomView.tsx
+++ b/src/app/features/room/RoomView.tsx
@@ -4,7 +4,7 @@ import { EventType } from 'matrix-js-sdk';
 import { ReactEditor } from 'slate-react';
 import { isKeyHotkey } from 'is-hotkey';
 import { useStateEvent } from '../../hooks/useStateEvent';
-import { StateEvent } from '../../../types/matrix/room';
+import { StateEvent, MessageEvent } from '../../../types/matrix/room';
 import { usePowerLevelsContext } from '../../hooks/usePowerLevels';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import { useEditor } from '../../components/editor';
@@ -71,7 +71,11 @@ export function RoomView({ eventId }: { eventId?: string }) {
   const creators = useRoomCreators(room);
 
   const permissions = useRoomPermissions(creators, powerLevels);
-  const canMessage = permissions.event(EventType.RoomMessage, mx.getSafeUserId());
+  const isEncrypted = mx.isRoomEncrypted(roomId);
+  const canMessage = permissions.event(
+    isEncrypted ? MessageEvent.RoomMessageEncrypted : EventType.RoomMessage,
+    mx.getSafeUserId()
+  );
 
   useKeyDown(
     window,


### PR DESCRIPTION
## Description

This PR fixes an issue where standard users were prevented from composing or sending messages in encrypted rooms if the power level required for `m.room.message` was elevated above their own (e.g. restricted to Admins). 

When a room is encrypted, users send `m.room.encrypted` events instead of `m.room.message` events. Previously, the `RoomView` component unconditionally checked for `m.room.message` permission to determine if the message composer should be rendered. This PR updates the logic to evaluate the correct `m.room.encrypted` permission when E2EE is enabled.

## Changes

- Updated `RoomView.tsx` to determine the encryption state of the room using `mx.isRoomEncrypted(roomId)`.
- Conditionally verify the composer permission against `MessageEvent.RoomMessageEncrypted` (`m.room.encrypted`) instead of `EventType.RoomMessage` when the room is encrypted.

Close: #3027