### PR TITLE
fix: Prevent hidden events from disrupting timeline date separators and message grouping

### DIFF
--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -1620,7 +1620,7 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
   );
 
   let prevEvent: MatrixEvent | undefined;
-  let isPrevRendered = false;
+  let prevRenderedEvent: MatrixEvent | undefined;
   let newDivider = false;
   let dayDivider = false;
   const eventRenderer = (item: number) => {
@@ -1640,25 +1640,25 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
       return null;
     }
 
+    const isVisible = !reactionOrEditEvent(mEvent);
+
     if (!newDivider && readUptoEventIdRef.current) {
       newDivider = prevEvent?.getId() === readUptoEventIdRef.current;
     }
-    if (!dayDivider) {
-      dayDivider = prevEvent ? !inSameDay(prevEvent.getTs(), mEvent.getTs()) : false;
+    if (isVisible && !dayDivider) {
+      dayDivider = prevRenderedEvent ? !inSameDay(prevRenderedEvent.getTs(), mEvent.getTs()) : false;
     }
 
     const collapsed =
-      isPrevRendered &&
       !dayDivider &&
       (!newDivider || eventSender === mx.getUserId()) &&
-      prevEvent !== undefined &&
-      prevEvent.getSender() === eventSender &&
-      prevEvent.getType() === mEvent.getType() &&
-      minuteDifference(prevEvent.getTs(), mEvent.getTs()) < 2;
+      prevRenderedEvent !== undefined &&
+      prevRenderedEvent.getSender() === eventSender &&
+      prevRenderedEvent.getType() === mEvent.getType() &&
+      minuteDifference(prevRenderedEvent.getTs(), mEvent.getTs()) < 2;
 
-    const eventJSX = reactionOrEditEvent(mEvent)
-      ? null
-      : renderMatrixEvent(
+    const eventJSX = isVisible
+      ? renderMatrixEvent(
           mEvent.getType(),
           typeof mEvent.getStateKey() === 'string',
           mEventId,
@@ -1666,9 +1666,12 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
           item,
           timelineSet,
           collapsed
-        );
+        )
+      : null;
     prevEvent = mEvent;
-    isPrevRendered = !!eventJSX;
+    if (isVisible) {
+      prevRenderedEvent = mEvent;
+    }
 
     const newDividerJSX =
       newDivider && eventJSX && eventSender !== mx.getUserId() ? (


### PR DESCRIPTION
## Description

This PR fixes an issue where the timeline would sometimes render multiple duplicate Date Separators on the same day. It also fixes a related visual issue where consecutive messages sent by the same user within a minute would fail to collapse (group together) and erroneously repeat the user's avatar.

The root cause was that hidden events (such as `m.reaction` or edits) were continually updating the `prevEvent` reference as they were processed. Because they are not rendered on screen, any date boundaries they crossed would leave the `dayDivider` state stuck as `true` for the *next* visible message. Furthermore, their presence between normal messages disrupted the sender matching in the `collapsed` grouping check.

## Changes

- Introduced `prevRenderedEvent` in `RoomTimeline.tsx` to strictly track the last *visible* event rendered in the timeline block.
- Updated the `dayDivider` and `collapsed` logic to evaluate against `prevRenderedEvent` instead of `prevEvent`.
- `prevEvent` is still maintained for other underlying logic, such as determining the read-receipt `newDivider` marker.

Close: #3071